### PR TITLE
Autogen docs improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"tailwind-merge": "^1.14.0",
 		"tailwindcss-animate": "^1.0.7",
 		"tiny-invariant": "^1.3.1",
-		"typedoc-better-json": "^0.7.0"
+		"typedoc-better-json": "^0.7.4"
 	},
 	"devDependencies": {
 		"@types/fs-extra": "^11.0.3",

--- a/src/app/references/components/TDoc/Accessor.tsx
+++ b/src/app/references/components/TDoc/Accessor.tsx
@@ -7,7 +7,7 @@ import { getTags } from "./utils/getTags";
 import { DeprecatedCalloutTDoc } from "./Deprecated";
 import { sluggerContext } from "@/contexts/slugger";
 import invariant from "tiny-invariant";
-import { Callout } from "@/components/Document";
+import { Callout, Details } from "@/components/Document";
 import { getTokenLinks } from "./utils/getTokenLinks";
 
 export async function AccessorTDoc(props: { doc: AccessorDoc; level: number }) {
@@ -40,11 +40,13 @@ export async function AccessorTDoc(props: { doc: AccessorDoc; level: number }) {
 				</Callout>
 			)}
 
-			<CodeBlock
-				lang="ts"
-				code={signatureCode}
-				tokenLinks={tokens ? await getTokenLinks(tokens) : undefined}
-			/>
+			<Details id="signature" summary="Signature">
+				<CodeBlock
+					lang="ts"
+					code={signatureCode}
+					tokenLinks={tokens ? await getTokenLinks(tokens) : undefined}
+				/>
+			</Details>
 
 			{exampleTag?.summary && (
 				<>

--- a/src/app/references/components/TDoc/Enum.tsx
+++ b/src/app/references/components/TDoc/Enum.tsx
@@ -34,8 +34,6 @@ export function EnumTDoc(props: { doc: EnumDoc; level: number }) {
 			{doc.summary && <TypedocSummary summary={doc.summary} />}
 			{remarksTag?.summary && <TypedocSummary summary={remarksTag.summary} />}
 
-			<CodeBlock lang="ts" code={code} />
-
 			{exampleTag?.summary && (
 				<>
 					<Heading level={subLevel} id={slugger.slug("example")}>
@@ -50,6 +48,8 @@ export function EnumTDoc(props: { doc: EnumDoc; level: number }) {
 					<TypedocSummary summary={seeTag.summary} />
 				</Callout>
 			)}
+
+			<CodeBlock lang="ts" code={code} />
 
 			{doc.members?.map((member) => {
 				return (
@@ -78,10 +78,7 @@ function MemberTDoc(props: {
 				{member.name}
 			</Heading>
 			{member.summary && <TypedocSummary summary={member.summary} />}
-			<CodeBlock
-				lang="ts"
-				code={`${props.enumName}.${member.name}: ${member.value}`}
-			/>
+			<CodeBlock lang="ts" code={`${member.value.code}`} />
 		</div>
 	);
 }

--- a/src/app/references/components/TDoc/Function.tsx
+++ b/src/app/references/components/TDoc/Function.tsx
@@ -15,6 +15,7 @@ import { sluggerContext } from "@/contexts/slugger";
 import invariant from "tiny-invariant";
 import { getTags } from "./utils/getTags";
 import { getTokenLinks } from "./utils/getTokenLinks";
+import { Paragraph } from "@/components/Document";
 
 export function FunctionTDoc(props: {
 	doc: FunctionDoc;
@@ -64,7 +65,7 @@ async function RenderFunctionSignature(props: {
 	const slugger = sluggerContext.get();
 	invariant(slugger, "slugger context not set");
 
-	const { deprecatedTag, remarksTag, seeTag, exampleTag } = getTags(
+	const { deprecatedTag, remarksTag, seeTag, exampleTag, prepareTag } = getTags(
 		signature.blockTags,
 	);
 
@@ -113,8 +114,6 @@ async function RenderFunctionSignature(props: {
 				</Callout>
 			)}
 
-			<CodeBlock code={signatureCode.code} lang="ts" tokenLinks={tokenLinks} />
-
 			{exampleTag?.summary && (
 				<>
 					<Heading level={subLevel} id={slugger.slug("example")}>
@@ -123,6 +122,16 @@ async function RenderFunctionSignature(props: {
 					<TypedocSummary summary={exampleTag.summary} />
 				</>
 			)}
+
+			<div className="mt-8">
+				<Details id={slugger.slug("signature")} summary="Signature">
+					<CodeBlock
+						code={signatureCode.code}
+						lang="ts"
+						tokenLinks={tokenLinks}
+					/>
+				</Details>
+			</div>
 
 			{signature.parameters && (
 				<div className="mt-5">
@@ -175,6 +184,24 @@ async function RenderFunctionSignature(props: {
 							/>
 						)}
 					</div>
+				</div>
+			)}
+
+			{prepareTag && (
+				<div className="mt-8">
+					<Callout variant="info" title="Preparable">
+						<Paragraph>
+							To gain more granular control over the transaction process, all
+							transaction methods come with a <InlineCode code={`prepare`} />{" "}
+							method that gives you full control over each step of this
+							transaction journey.
+						</Paragraph>
+
+						<Paragraph>
+							You can prepare <InlineCode code={name} /> method by calling{" "}
+							<InlineCode code={`${name}.prepare()`} /> with same arguments.
+						</Paragraph>
+					</Callout>
 				</div>
 			)}
 

--- a/src/app/references/components/TDoc/utils/getSidebarLinkgroups.ts
+++ b/src/app/references/components/TDoc/utils/getSidebarLinkgroups.ts
@@ -1,17 +1,99 @@
 import { SomeDoc } from "@/app/references/components/TDoc/types";
-import { TransformedDoc } from "typedoc-better-json";
-import { LinkGroup } from "../../../../../components/others/Sidebar";
+import { BlockTag, TransformedDoc } from "typedoc-better-json";
+import {
+	LinkGroup,
+	SidebarLink,
+} from "../../../../../components/others/Sidebar";
+
+function getCustomTag(doc: SomeDoc): string | undefined {
+	function findTag(blockTags?: BlockTag[]): string | undefined {
+		if (!blockTags) {
+			return;
+		}
+		const tag = blockTags.find((t) => t.tag === "@tags");
+		if (
+			tag &&
+			tag.summary &&
+			tag.summary[0] &&
+			tag.summary[0].type === "paragraph" &&
+			tag.summary[0].children[0] &&
+			tag.summary[0].children[0].type === "text"
+		) {
+			return tag.summary[0].children[0].value;
+		}
+	}
+
+	switch (doc.kind) {
+		case "class": {
+			return findTag(doc.blockTags);
+		}
+		case "function": {
+			if (doc.signatures && doc.signatures[0] && doc.signatures[0].blockTags) {
+				return findTag(doc.signatures?.[0].blockTags);
+			}
+			return undefined;
+		}
+
+		case "variable": {
+			return findTag(doc.blockTags);
+		}
+
+		case "enum": {
+			return findTag(doc.blockTags);
+		}
+
+		case "accessor": {
+			return findTag(doc.blockTags);
+		}
+
+		case "type": {
+			return findTag(doc.blockTags);
+		}
+	}
+}
 
 export function getSidebarLinkGroups(doc: TransformedDoc, path: string) {
 	const linkGroups: LinkGroup[] = [];
 
 	function createLinkGroup(name: string, docs: SomeDoc[]) {
-		linkGroups.push({
-			name: name,
-			links: docs.map((d) => ({
+		const groups: Record<string, SomeDoc[]> = {};
+		const noGroups: SomeDoc[] = [];
+
+		docs.forEach((d) => {
+			const tag = getCustomTag(d);
+
+			if (tag) {
+				if (!groups[tag]) {
+					groups[tag] = [];
+				}
+				groups[tag]!.push(d);
+			} else {
+				noGroups.push(d);
+			}
+		});
+
+		const links: SidebarLink[] = [];
+
+		Object.entries(groups).forEach(([tag, docs]) => {
+			links.push({
+				name: tag,
+				links: docs.map((d) => ({
+					name: d.name,
+					href: `${path}/${d.name}`,
+				})),
+			});
+		});
+
+		noGroups.forEach((d) => {
+			links.push({
 				name: d.name,
 				href: `${path}/${d.name}`,
-			})),
+			});
+		});
+
+		linkGroups.push({
+			name: name,
+			links: links,
 		});
 	}
 

--- a/src/app/references/components/TDoc/utils/getTags.ts
+++ b/src/app/references/components/TDoc/utils/getTags.ts
@@ -6,10 +6,14 @@ export function getTags(blockTags?: BlockTag[]) {
 	const remarksTag = blockTags?.find((t) => t.tag === "@remarks");
 	const seeTag = blockTags?.find((t) => t.tag === "@see");
 
+	// this is add manually by us in docs repo
+	const prepareTag = blockTags?.find((t) => t.tag === "@prepare");
+
 	return {
 		exampleTag,
 		deprecatedTag,
 		remarksTag,
 		seeTag,
+		prepareTag,
 	};
 }

--- a/src/components/Document/Code.tsx
+++ b/src/components/Document/Code.tsx
@@ -125,20 +125,24 @@ export async function CodeBlock(props: {
 	}
 
 	return (
-		<code
-			className="styled-scrollbar relative mb-5 block max-h-[80vh] overflow-auto rounded-md border bg-b-800 p-4 font-mono text-sm leading-7"
-			lang={lang}
-		>
-			<CopyButton text={code} />
-			<pre
-				className=""
-				dangerouslySetInnerHTML={
-					ReactElement ? undefined : { __html: highlightedCode }
-				}
+		<div className="relative">
+			<code
+				className="styled-scrollbar relative mb-5 block max-h-[80vh] overflow-auto rounded-md border bg-b-800 p-4 font-mono text-sm leading-7"
+				lang={lang}
 			>
-				{ReactElement}
-			</pre>
-		</code>
+				<pre
+					dangerouslySetInnerHTML={
+						ReactElement ? undefined : { __html: highlightedCode }
+					}
+				>
+					{ReactElement}
+				</pre>
+			</code>
+
+			<div className="absolute right-4 top-4 z-10">
+				<CopyButton text={code} />
+			</div>
+		</div>
 	);
 }
 

--- a/src/components/Document/Details.tsx
+++ b/src/components/Document/Details.tsx
@@ -49,8 +49,8 @@ export function Details(props: {
 					<Anchor id={id || "#"} className={"m-0 flex gap-3"}>
 						<h4
 							className={cn(
-								"text-3xl md:text-4xl font-bold tracking-tight text-f-100 break-all ",
-								"text-base md:text-base font-semibold text-accent-500 flex gap-3 text-left w-full",
+								"text-lg font-bold tracking-tight text-f-100 break-all",
+								"font-semibold text-accent-500 flex gap-3 text-left w-full",
 								props.headingClassName,
 							)}
 						>

--- a/src/components/Document/Details.tsx
+++ b/src/components/Document/Details.tsx
@@ -72,7 +72,8 @@ export function Details(props: {
 						)}
 					</Anchor>
 				</AccordionTrigger>
-				<AccordionContent>
+
+				<AccordionContent data-collapsible>
 					<div className="pl-4 pt-4 [&>:first-child]:mt-0">
 						{props.children}
 					</div>

--- a/src/components/others/CopyButton.tsx
+++ b/src/components/others/CopyButton.tsx
@@ -18,8 +18,8 @@ export function CopyButton(props: { text: string }) {
 	return (
 		<Button
 			variant="outline"
-			className="absolute right-4 top-4 p-2"
 			onClick={copyToClipboard}
+			className="bg-b-900 p-2"
 		>
 			<Icon className="h-3 w-3 text-f-300" />
 		</Button>

--- a/src/components/others/TableOfContents.tsx
+++ b/src/components/others/TableOfContents.tsx
@@ -37,9 +37,14 @@ export function TableOfContentsSideBar() {
 		if (!root) throw new Error("No main element found");
 
 		// get all anchor links in root
-		const anchors = Array.from(
+		const anchorsAll = Array.from(
 			root.querySelectorAll("a[href^='#']"),
 		) as HTMLAnchorElement[];
+
+		// hide anchors inside hidden elements
+		const anchors = anchorsAll.filter((anchor) => {
+			return anchor.closest("[data-collapsible]") === null;
+		});
 
 		// when heading's intersection changes, update corresponding link's data-active attribute to true/false
 		const observer = new IntersectionObserver(

--- a/yarn.lock
+++ b/yarn.lock
@@ -5476,10 +5476,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typedoc-better-json@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/typedoc-better-json/-/typedoc-better-json-0.7.0.tgz#cfa0d518432ac582951ffde614b2be0f2fa91f35"
-  integrity sha512-MZduBzObhTXNzpf0ea7KEYSyhF1oNSJ8zeCLTwY7kV0Lhzc/HQf1FoPNfWDrNGmRgmsW3Pe7VvPLz1vAwwfMkA==
+typedoc-better-json@^0.7.4:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/typedoc-better-json/-/typedoc-better-json-0.7.4.tgz#b5f15960138f7a1ae2db11bae45280fcc6373d2f"
+  integrity sha512-3Mh6fnE+l7eHGDoDDz1Co5I05F42W0SxirKF3Sdu1gXfRgoCub07AHNDpoitNBLgQFwJtIhkMaGnk3Umsg+JZA==
   dependencies:
     mdast "^3.0.0"
     mdast-util-from-markdown "^2.0.0"


### PR DESCRIPTION
* Make signature collapse 
* Fix prepare 
* Show function properties as methods
* Hide the prepare signature and just show "this method is preparable callout"
* group the sidebar links by "@tags" name in autogenerated docs
