### PR TITLE
Update page.mdx-You can not export other than network handler in route.ts

### DIFF
--- a/src/app/connect/auth/server-frameworks/next/page.mdx
+++ b/src/app/connect/auth/server-frameworks/next/page.mdx
@@ -84,7 +84,9 @@ Finally, we export the `ThirdwebAuthHandler` which sets up all the `/api/auth/*`
 
 Alternatively, we can setup auth using the app router. We can setup our [Auth API](/auth/how-auth-works/auth-api) by creating a new file called `app/api/auth/[...thirdweb]/route.ts` as follows:
 
-```ts title="pages/api/auth/[...thirdweb].ts"
+Create a separate file named like `thirdwebAuth.ts`:
+
+```ts title="app/api/auth/[...thirdweb]/thirdwebAuth.ts"
 import { ThirdwebAuthAppRouter } from "@thirdweb-dev/auth/next";
 import { PrivateKeyWallet } from "@thirdweb-dev/auth/evm";
 
@@ -92,6 +94,12 @@ export const { ThirdwebAuthHandler, getUser } = ThirdwebAuthAppRouter({
 	domain: "example.com",
 	wallet: new PrivateKeyWallet(process.env.THIRDWEB_AUTH_PRIVATE_KEY || ""),
 });
+```
+
+Import `thirdwebAuth.ts` in your `app/api/auth/[...thirdweb]/route.ts` file:
+
+```ts title="app/api/auth/[...thirdweb]/route.ts"
+import { ThirdwebAuthHandler } from "./thirdwebAuth";
 
 export { ThirdwebAuthHandler as GET, ThirdwebAuthHandler as POST };
 ```


### PR DESCRIPTION
The default document example for app directory intergration reports errors as follow:

```
app/api/auth/[...thirdweb]/route.ts
Type error: Route "app/api/auth/[...thirdweb]/route.ts" does not match the required types of a Next.js Route.
  "ThirdwebAuthHandler" is not a valid Route export field.
```

This is caused by the first export line:

```
export const { ThirdwebAuthHandler, getUser } = ThirdwebAuthAppRouter(
```

So you should create a new file for handler and then import it in `route.ts`