### PR TITLE
Fix disabled scroll on sdk version toggle

### DIFF
--- a/src/app/Header.tsx
+++ b/src/app/Header.tsx
@@ -89,14 +89,6 @@ const supportLinks = [
 export function Header() {
 	const [showBurgerMenu, setShowBurgerMenu] = useState(false);
 
-	useEffect(() => {
-		if (showBurgerMenu) {
-			document.body.style.overflow = "hidden";
-		} else {
-			document.body.style.overflow = "auto";
-		}
-	}, [showBurgerMenu]);
-
 	return (
 		<header className="flex w-full items-center border-b bg-b-900">
 			<div

--- a/src/components/others/Sidebar.tsx
+++ b/src/components/others/Sidebar.tsx
@@ -242,16 +242,7 @@ function DocSidebarCategory(props: {
 }
 
 export function DocSidebarMobile(props: ReferenceSideBarProps) {
-	const [open, _setOpen] = useState(false);
-
-	const setOpen = (value: boolean) => {
-		if (value) {
-			document.body.style.overflow = "hidden";
-		} else {
-			document.body.style.overflow = "auto";
-		}
-		_setOpen(value);
-	};
+	const [open, setOpen] = useState(false);
 
 	return (
 		<DropdownMenu open={open} onOpenChange={setOpen}>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to refactor the handling of the `open` state in the `DocSidebarMobile` component to simplify the code and improve readability.

### Detailed summary
- Simplified the state management by directly setting the `open` state in `useState`
- Removed redundant code for setting `document.body.style.overflow` based on the `open` state

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->