### PR TITLE
Fix: installation packages in expo-page on page.mdx

### DIFF
--- a/src/app/react-native/v0/installation/page.mdx
+++ b/src/app/react-native/v0/installation/page.mdx
@@ -129,9 +129,9 @@ npx expo prebuild
 Now, we can add the dependencies:
 
 <InstallTabs
-	npm="npm i 'ethers@^5' @thirdweb-dev/react-native @thirdweb-dev/react-native-compat node-libs-browser react-native-crypto react-native-randombytes react-native-get-random-values 'react-native-svg@^13.9.0' react-native-mmkv @react-native-async-storage/async-storage"
-	yarn="yarn add 'ethers@^5' @thirdweb-dev/react-native @thirdweb-dev/react-native-compat node-libs-browser react-native-crypto react-native-randombytes react-native-get-random-values 'react-native-svg@^13.9.0' react-native-mmkv @react-native-async-storage/async-storage"
-	pnpm="pnpm i 'ethers@^5' @thirdweb-dev/react-native @thirdweb-dev/react-native-compat node-libs-browser react-native-crypto react-native-randombytes react-native-get-random-values 'react-native-svg@^13.9.0' react-native-mmkv @react-native-async-storage/async-storage"
+	npm="npm i ethers@^5 @thirdweb-dev/react-native @thirdweb-dev/react-native-compat node-libs-browser react-native-crypto react-native-randombytes react-native-get-random-values react-native-svg@^13.9.0 react-native-mmkv @react-native-async-storage/async-storage"
+	yarn="yarn add ethers@^5 @thirdweb-dev/react-native @thirdweb-dev/react-native-compat node-libs-browser react-native-crypto react-native-randombytes react-native-get-random-values react-native-svg@^13.9.0 react-native-mmkv @react-native-async-storage/async-storage"
+	pnpm="pnpm i ethers@^5 @thirdweb-dev/react-native @thirdweb-dev/react-native-compat node-libs-browser react-native-crypto react-native-randombytes react-native-get-random-values react-native-svg@^13.9.0 react-native-mmkv @react-native-async-storage/async-storage"
 />
 
 Our wallets package uses the Expo Modules API, please [configure it](https://docs.expo.dev/modules/overview/) in your app:


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the installation commands in `page.mdx` for the wallets package by removing single quotes around package names.

### Detailed summary
- Updated npm, yarn, and pnpm installation commands by removing single quotes around package names.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->