### PR TITLE
Fixes minor typo

### DIFF
--- a/src/app/typescript/v5/react/components/ConnectEmbed/page.mdx
+++ b/src/app/typescript/v5/react/components/ConnectEmbed/page.mdx
@@ -60,7 +60,7 @@ const wallets = [
 function Example() {
 	return (
 		<div>
-			<ConnectEmbed client={client} wallets={walllets} />
+			<ConnectEmbed client={client} wallets={wallets} />
 		</div>
 	);
 }


### PR DESCRIPTION
Minor typo on variable

<!-- start pr-codex -->

---

## PR-Codex overview
This PR fixes a typo in the `wallets` prop name in the `ConnectEmbed` component.

### Detailed summary
- Fixed a typo in the `wallets` prop name from `walllets` to `wallets` in the `ConnectEmbed` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->