### PR TITLE
fix: Update wallet href in React components and page

### DIFF
--- a/src/app/typescript/v5/react/components/ConnectButton/page.mdx
+++ b/src/app/typescript/v5/react/components/ConnectButton/page.mdx
@@ -66,7 +66,7 @@ function Example() {
 <ArticleIconCard
 	title="Supported Wallets"
 	icon={TablePropertiesIcon}
-	href="/typescript/v5/react/wallets"
+	href="/typescript/v5/supported-wallets"
 />
 
 </Stack>

--- a/src/app/typescript/v5/react/components/ConnectEmbed/page.mdx
+++ b/src/app/typescript/v5/react/components/ConnectEmbed/page.mdx
@@ -71,7 +71,7 @@ function Example() {
 <ArticleIconCard
 	title="Supported Wallets"
 	icon={TablePropertiesIcon}
-	href="/typescript/v5/react/wallets"
+	href="/typescript/v5/supported-wallets"
 />
 
 </Stack>

--- a/src/app/typescript/v5/react/page.mdx
+++ b/src/app/typescript/v5/react/page.mdx
@@ -35,7 +35,7 @@ import {
 <ArticleIconCard
 	title="Supported Wallets"
 	icon={WalletIcon}
-	href="/typescript/v5/react/wallets"
+	href="/typescript/v5/supported-wallets"
 />
 
 <ArticleIconCard


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the href links for "Supported Wallets" across multiple components in the React application to point to `/typescript/v5/supported-wallets` instead of `/typescript/v5/react/wallets`.

### Detailed summary
- Updated href links for "Supported Wallets" in `page.mdx` and `ConnectEmbed` and `ConnectButton` components to point to `/typescript/v5/supported-wallets`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->