### PR TITLE
Update supported chains on payments page

### DIFF
--- a/src/app/payments/page.mdx
+++ b/src/app/payments/page.mdx
@@ -45,10 +45,6 @@ thirdweb currently supports checkout for NFTs on any of the following chains wit
 | :------------------- | :------------------- |
 | Arbitrum Sepolia     | ETH                  |
 | Avalanche Fuji       | AVAX                 |
-| Base Goerli          | ETH                  |
-| Goerli               | ETH, USDC            |
-| Mumbai               | MATIC, USDC          |
-| Optimism Goerli      | ETH                  |
 | Sepolia              | ETH                  |
 | Zora Testnet         | ETH                  |
 

--- a/src/app/payments/page.mdx
+++ b/src/app/payments/page.mdx
@@ -45,6 +45,7 @@ thirdweb currently supports checkout for NFTs on any of the following chains wit
 | :------------------- | :------------------- |
 | Arbitrum Sepolia     | ETH                  |
 | Avalanche Fuji       | AVAX                 |
+| Base Sepolia	       | ETH                  |
 | Sepolia              | ETH                  |
 | Zora Testnet         | ETH                  |
 


### PR DESCRIPTION
This PR removes `Base Goerli` ,Goerli`, `Optimism Goerli` from supported testnets for payments & adds `Base Sepolia` as supported testnet


