### PR TITLE
Fix hook classification in references

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"tailwindcss-animate": "^1.0.7",
 		"thirdweb": "^5.3.1",
 		"tiny-invariant": "^1.3.1",
-		"typedoc-better-json": "^0.9.1"
+		"typedoc-better-json": "^0.9.2"
 	},
 	"devDependencies": {
 		"@types/flexsearch": "^0.7.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ dependencies:
     specifier: ^1.3.1
     version: 1.3.1
   typedoc-better-json:
-    specifier: ^0.9.1
-    version: 0.9.1(typescript@5.3.3)
+    specifier: ^0.9.2
+    version: 0.9.2(typescript@5.3.3)
 
 devDependencies:
   '@types/flexsearch':
@@ -8169,8 +8169,8 @@ packages:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
     dev: true
 
-  /typedoc-better-json@0.9.1(typescript@5.3.3):
-    resolution: {integrity: sha512-z3F6kbCD7g4a7w9lf7VRzgRqp4Ie3hQBCGjxJRhi5D5Q65Y/ofnKPLEJygGrWVmaabvjUHRkGG2xL01U1UPA0A==}
+  /typedoc-better-json@0.9.2(typescript@5.3.3):
+    resolution: {integrity: sha512-p2D1/0KixD/mVdsB0hQHwd2il2ksjfRN42RloOkEp4vmok5F2dvoqIJwgU8+HgdTS3aOW0OeR7L8jp1ALW6Nzg==}
     dependencies:
       mdast: 3.0.0
       mdast-util-from-markdown: 2.0.0


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates `typedoc-better-json` to version `0.9.2`, enhancing documentation generation. 

### Detailed summary
- Updated `typedoc-better-json` to `0.9.2` from `0.9.1`
- Updated version in `pnpm-lock.yaml` for TypeScript compatibility

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->