### PR TITLE
Add Polygon Amoy Testnet support to payments

### DIFF
--- a/src/app/payments/page.mdx
+++ b/src/app/payments/page.mdx
@@ -48,6 +48,7 @@ thirdweb currently supports checkout for NFTs on any of the following chains wit
 | Base Sepolia	       | ETH                  |
 | Sepolia              | ETH                  |
 | Zora Testnet         | ETH                  |
+| Polygon Amoy Testnet | MATIC                |
 
 ### Fraud prevention & chargeback protection
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds support for `Polygon Amoy Testnet` with `MATIC` as a payment option. 

### Detailed summary
- Added `Polygon Amoy Testnet` as a payment option with `MATIC`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->