### PR TITLE
Chore: Block iframes, update Engine docs on overloaded methods

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -16,6 +16,7 @@ const nextConfig = {
 		return [
 			// Disallow all pages from being embedded in an iframe.
 			{
+				source: "/:path*",
 				headers: [
 					{
 						key: "Content-Security-Policy",

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -12,6 +12,23 @@ const withMDX = createMDX({
 const nextConfig = {
 	pageExtensions: ["mdx", "tsx", "ts"],
 	redirects,
+	headers: async () => {
+		return [
+			// Disallow all pages from being embedded in an iframe.
+			{
+				headers: [
+					{
+						key: "Content-Security-Policy",
+						value: `frame-ancestors 'none';`,
+					},
+					{
+						key: "X-Frame-Options",
+						value: "DENY",
+					},
+				],
+			},
+		];
+	},
 };
 
 export default withMDX(nextConfig);

--- a/src/app/engine/features/contracts/page.mdx
+++ b/src/app/engine/features/contracts/page.mdx
@@ -1,4 +1,4 @@
-import { createMetadata } from "@doc";
+import { Details, createMetadata } from "@doc";
 
 export const metadata = createMetadata({
 	title: "Contracts | thirdweb Engine",
@@ -40,7 +40,34 @@ const { result } = await resp.json();
 console.log("Queue ID:", result.queueId);
 ```
 
-[See API reference.](https://redocly.github.io/redoc/?url=https://demo.web3api.thirdweb.com/json#tag/Contract/operation/write)
+<Details id="handling-overloaded-functions" summary="Handling overloaded functions">
+
+If there are multiple signatures for `functionName` on the contract, provide the full signature with args.
+
+**Example**
+
+Your contract has two functions named `mintTo`:
+
+```solidity
+function mintTo(address to) public
+```
+
+```solidity
+function mintTo(address to, uint256 quantity) public
+```
+
+This is the request body to call the second function:
+
+```json
+{
+	"functionName": "mintTo(address, uint256)",
+	"args": ["0x4Ff9aa707AE1eAeb40E581DF2cf4e14AffcC553d", "3"]
+}
+```
+
+</Details>
+
+[See API reference](https://redocly.github.io/redoc/?url=https://demo.web3api.thirdweb.com/json#tag/Contract/operation/write)
 
 ### Call a payable method
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add security headers to disallow page embedding in iframes and provide guidance on handling overloaded functions in contracts.

### Detailed summary
- Added security headers to disallow page embedding in iframes
- Imported `Details` and `createMetadata` from `@doc` in `page.mdx`
- Provided guidance on calling overloaded functions in contracts

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->