### PR TITLE
Unity 4.12.1

### DIFF
--- a/src/app/unity/wallets/actions/authenticate/page.mdx
+++ b/src/app/unity/wallets/actions/authenticate/page.mdx
@@ -6,14 +6,14 @@ export const metadata = createMetadata({
 		"Authenticate the user by signing a payload that can be used to securely identify users.",
 });
 
-# Authenticate
+# AuthenticateAndLoginServerSide
 
 Using [Auth](/auth), authenticate the user by signing a payload that can be used to securely identify users.
 
 ## Usage
 
 ```csharp
-var data = await sdk.Wallet.Authenticate("domain");
+string token = await sdk.Wallet.AuthenticateAndLoginServerSide("domain", 1);
 ```
 
 ## Configuration
@@ -24,27 +24,20 @@ The domain you used in your authentication backend.
 
 [Learn more about how auth works](/auth/how-auth-works/sign-in-with-wallet).
 
+### chainId
+
+The chain ID of the blockchain you want to authenticate with.
+
+### authPayloadPath (optional)
+
+The payload generation endpoint in your backend. Defaults to `/auth/payload`.
+
+### authLoginPath (optional)
+
+The login endpoint in your backend. Defaults to `/auth/login`.
+
 Must be a `string`.
 
 ## Return Value
 
-Returns a `LoginPayload` struct containing the following properties:
-
-```csharp
-{
-  string signature;
-  {
-    string domain;
-    string address;
-    string statement;
-    string uri;
-    string version;
-    string chain_id;
-    string nonce;
-    string issued_at;
-    string expiration_time;
-    string invalid_before;
-    List<string> resources;
-  }
-}
-```
+A `string` representing the final post-login auth token returned by the server.


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to rename the `Authenticate` function to `AuthenticateAndLoginServerSide` and update the return value description in the `page.mdx` file.

### Detailed summary
- Renamed `Authenticate` to `AuthenticateAndLoginServerSide`
- Updated the return value description to a `string` representing the final post-login auth token

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->