### PR TITLE
Update page.mdx

### DIFF
--- a/src/app/typescript/v5/react/components/AutoConnect/page.mdx
+++ b/src/app/typescript/v5/react/components/AutoConnect/page.mdx
@@ -48,7 +48,7 @@ function Example() {
 	return (
 		<AutoConnect
 			client={client}
-			autoConnect={{ timeout: 10000 }}
+			timeout={10000}
 			wallets={wallets}
 			appMetadata={appMetadata}
 		/>


### PR DESCRIPTION
there's no `autoConnect` props in <AutoConnect>, we can only use `timeout`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `AutoConnect` component in `page.mdx` to replace the `autoConnect` prop with `timeout`.

### Detailed summary
- Replaced `autoConnect` prop with `timeout` prop in `AutoConnect` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->