### PR TITLE
Add secretKey in next.js auth examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"flexsearch": "^0.7.31",
 		"github-slugger": "^2.0.0",
 		"lucide-react": "^0.286.0",
-		"next": "~13.4",
+		"next": "13.4",
 		"nextjs-toploader": "^1.5.3",
 		"node-html-parser": "^6.1.11",
 		"posthog-js": "^1.96.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,7 +54,7 @@ dependencies:
     specifier: ^0.286.0
     version: 0.286.0(react@18.2.0)
   next:
-    specifier: ~13.4
+    specifier: '13.4'
     version: 13.4.19(react-dom@18.2.0)(react@18.2.0)
   nextjs-toploader:
     specifier: ^1.5.3

--- a/src/app/connect/auth/get-started/page.mdx
+++ b/src/app/connect/auth/get-started/page.mdx
@@ -82,6 +82,9 @@ import { PrivateKeyWallet } from "@thirdweb-dev/auth/evm";
 export const { ThirdwebAuthHandler, getUser } = ThirdwebAuth({
 	domain: process.env.NEXT_PUBLIC_THIRDWEB_AUTH_DOMAIN || "",
 	wallet: new PrivateKeyWallet(process.env.THIRDWEB_AUTH_PRIVATE_KEY || ""),
+	thirdwebAuthOptions: {
+		secretKey: "...",
+	},
 });
 
 // Use the ThirdwebAuthHandler as the default export to handle all requests to /api/auth/*

--- a/src/app/connect/auth/server-frameworks/express/page.mdx
+++ b/src/app/connect/auth/server-frameworks/express/page.mdx
@@ -50,6 +50,9 @@ const app = express();
 const { authRouter, authMiddleware, getUser } = ThirdwebAuth({
 	domain: process.env.THIRDWEB_AUTH_DOMAIN || "",
 	wallet: new PrivateKeyWallet(process.env.THIRDWEB_AUTH_PRIVATE_KEY || ""),
+	thirdwebAuthOptions: {
+		secretKey: "...",
+	},
 });
 
 // Add the auth router to our app to set up the /auth/* endpoints
@@ -176,6 +179,9 @@ export const { ThirdwebAuthHandler, getUser } = ThirdwebAuth({
   authOptions: {
     tokenDurationInSeconds: 60 * 60 * 24 * 7, // 1 week
   },
+  thirdwebAuthOptions: {
+		secretKey: "...",
+	},
 });
 ```
 

--- a/src/app/connect/auth/server-frameworks/next/page.mdx
+++ b/src/app/connect/auth/server-frameworks/next/page.mdx
@@ -66,6 +66,9 @@ import { PrivateKeyWallet } from "@thirdweb-dev/auth/evm";
 export const { ThirdwebAuthHandler, getUser } = ThirdwebAuth({
 	domain: "example.com",
 	wallet: new PrivateKeyWallet(process.env.THIRDWEB_AUTH_PRIVATE_KEY || ""),
+	thirdwebAuthOptions: {
+		secretKey: "...",
+	},
 });
 
 export default ThirdwebAuthHandler();
@@ -96,6 +99,9 @@ import { PrivateKeyWallet } from "@thirdweb-dev/auth/evm";
 export const { ThirdwebAuthHandler, getUser } = ThirdwebAuthAppRouter({
 	domain: "example.com",
 	wallet: new PrivateKeyWallet(process.env.THIRDWEB_AUTH_PRIVATE_KEY || ""),
+	thirdwebAuthOptions: {
+		secretKey: "...",
+	},
 });
 ```
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the version specifier for `next` package, adds `thirdwebAuthOptions` object, and includes it in multiple files for authentication handling.

### Detailed summary
- Updated `next` package version specifier in `pnpm-lock.yaml` and `package.json`
- Added `thirdwebAuthOptions` object with `secretKey` in authentication handling files

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->