### PR TITLE
Add few more hooks/methods for migration page (v4 -> v5)

### DIFF
--- a/src/app/typescript/v5/migrate/page.mdx
+++ b/src/app/typescript/v5/migrate/page.mdx
@@ -76,7 +76,7 @@ const onClick = async () => {
 | Prepare    | `await contract.prepare(...)`                            | `prepareContractCall(...) // no await`            |
 | Send       | `await contract.call(...)`                               | `await sendTransaction(...)`                      |
 | Extensions | `await contract.erc721.getAll()`                         | `await getNFTs(...)`                              |
-| Deploy     | `sdk.deployer.deployBuiltInContract(...)`                | `await getNFTs(...)`                              |
+| Deploy     | `sdk.deployer.deployBuiltInContract(...)`                | `await deployPublishedContract(...)`              |
 
 
 ### React Cheatsheet
@@ -90,9 +90,9 @@ const onClick = async () => {
 | Write                | `useContractWrite(...)`                               | `useSendTransaction()`                              |
 | Extensions           | `useNFTs(...)`                                        | `useReadContract(getNFTs, { ... })`                 |
 | Get Signer           | `useSigner()`                                         | `useActiveAccount()`                                |
-| Get Wallet           | `useWallet()`                                         | `await deployedPublishedContract(...)`              |
+| Get Wallet           | `useWallet()`                                         | `useActiveWallet()`                                 |
 | Button               | `Web3Button`                                          | `TransactionButton`                                 |
 | Connect              | `ConnectWallet`                                       | `ConnectButton`                                     |
 | Connection Status    | `useConnectionStatus()`                               | `useActiveWalletConnectionStatus()`                 |
 | Switch Chain         | `useSwitchChain()`                                    | `useSwitchActiveWalletChain()`                      |
-| Get Connected Chain  | `useChain ()`                                         | `useSwitchActiveWalletChain()`                      |
+| Get Connected Chain  | `useChain()`                                          | `useSwitchActiveWalletChain()`                      |

--- a/src/app/typescript/v5/migrate/page.mdx
+++ b/src/app/typescript/v5/migrate/page.mdx
@@ -76,14 +76,23 @@ const onClick = async () => {
 | Prepare    | `await contract.prepare(...)`                            | `prepareContractCall(...) // no await`            |
 | Send       | `await contract.call(...)`                               | `await sendTransaction(...)`                      |
 | Extensions | `await contract.erc721.getAll()`                         | `await getNFTs(...)`                              |
+| Deploy     | `sdk.deployer.deployBuiltInContract(...)`                | `await getNFTs(...)`                              |
+
 
 ### React Cheatsheet
 
-| Task       | `@thirdweb-dev/react`                                 | `thirdweb`                                          |
-| ---------- | ----------------------------------------------------- | --------------------------------------------------- |
-| Provider   | `import { ThirdwebProvider} from @thirdweb-dev/react` | `import { ThirdwebProvider } from "thirdweb/react"` |
-| Contract   | `useContract(...)`                                    | `getContract(...) // not a hook`                    |
-| Address    | `useAddress(...)`                                     | `useActiveAccount(...) // account?.address`         |
-| Read       | `useContractRead(...)`                                | `useReadContract(...)`                              |
-| Write      | `useContractWrite(...)`                               | `useSendTransaction()`                              |
-| Extensions | `useNFTs(...)`                                        | `useReadContract(getNFTs, { ... })`                 |
+| Task                 | `@thirdweb-dev/react`                                 | `thirdweb`                                          |
+| ---------------------| ----------------------------------------------------- | --------------------------------------------------- |
+| Provider             | `import { ThirdwebProvider} from @thirdweb-dev/react` | `import { ThirdwebProvider } from "thirdweb/react"` |
+| Contract             | `useContract(...)`                                    | `getContract(...) // not a hook`                    |
+| Address              | `useAddress(...)`                                     | `useActiveAccount(...) // account?.address`         |
+| Read                 | `useContractRead(...)`                                | `useReadContract(...)`                              |
+| Write                | `useContractWrite(...)`                               | `useSendTransaction()`                              |
+| Extensions           | `useNFTs(...)`                                        | `useReadContract(getNFTs, { ... })`                 |
+| Get Signer           | `useSigner()`                                         | `useActiveAccount()`                                |
+| Get Wallet           | `useWallet()`                                         | `await deployedPublishedContract(...)`              |
+| Button               | `Web3Button`                                          | `TransactionButton`                                 |
+| Connect              | `ConnectWallet`                                       | `ConnectButton`                                     |
+| Connection Status    | `useConnectionStatus()`                               | `useActiveWalletConnectionStatus()`                 |
+| Switch Chain         | `useSwitchChain()`                                    | `useSwitchActiveWalletChain()`                      |
+| Get Connected Chain  | `useChain ()`                                         | `useSwitchActiveWalletChain()`                      |


### PR DESCRIPTION
Added a few methods/functons/hooks in the migration guide for v4 -> v5

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates function calls and imports in `page.mdx` and `React Cheatsheet` for better readability and consistency.

### Detailed summary
- Renamed function calls in `page.mdx` for clarity
- Updated imports and function names in `React Cheatsheet` for consistency
- Added new functions for getting signer and wallet information
- Replaced `Web3Button` with `TransactionButton`
- Updated component names for wallet connection and chain switching

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

The above pr-codes, is not accurate ^