### PR TITLE
Fix different APIs with same name sharing same page in references

### DIFF
--- a/src/app/references/components/TDoc/utils/getSidebarLinkgroups.ts
+++ b/src/app/references/components/TDoc/utils/getSidebarLinkgroups.ts
@@ -5,6 +5,7 @@ import {
 	SidebarLink,
 } from "../../../../../components/others/Sidebar";
 import { subgroups } from "./subgroups";
+import { uniqueSlugger } from "./uniqueSlugger";
 
 const tagsToGroup = {
 	"@contract": "Contract",
@@ -120,6 +121,17 @@ function getCustomTag(doc: SomeDoc): [TagKey, string | undefined] | undefined {
 
 export function getSidebarLinkGroups(doc: TransformedDoc, path: string) {
 	const linkGroups: LinkGroup[] = [];
+	const generatedLinks = new Set<string>();
+
+	const getLink = (href: string) => {
+		const link = uniqueSlugger({
+			base: href,
+			isUnique: (s) => !generatedLinks.has(s),
+		});
+
+		generatedLinks.add(link);
+		return link;
+	};
 
 	// group links by tags
 	function createSubGroups(key: keyof typeof subgroups, docs: SomeDoc[]) {
@@ -155,7 +167,7 @@ export function getSidebarLinkGroups(doc: TransformedDoc, path: string) {
 				([extensionName, docs]) => {
 					const links = docs.map((d) => ({
 						name: d.name,
-						href: `${path}/${extensionName.toLowerCase()}/${d.name}`,
+						href: getLink(`${path}/${extensionName.toLowerCase()}/${d.name}`),
 					}));
 					return {
 						name: extensionName,
@@ -166,7 +178,7 @@ export function getSidebarLinkGroups(doc: TransformedDoc, path: string) {
 			if (!linkGroups.find((group) => group.name === name)) {
 				linkGroups.push({
 					name: name,
-					href: `${path}/${key}`,
+					href: getLink(`${path}/${key}`),
 					links: [{ name: "Extensions", links: extensionLinkGroups }],
 				});
 			} else {
@@ -224,7 +236,7 @@ export function getSidebarLinkGroups(doc: TransformedDoc, path: string) {
 				name: tagsToGroup[tag],
 				links: groupDocs.map((d) => ({
 					name: d.name,
-					href: `${path}/${d.name}`,
+					href: getLink(`${path}/${d.name}`),
 				})),
 			});
 		};
@@ -236,7 +248,7 @@ export function getSidebarLinkGroups(doc: TransformedDoc, path: string) {
 		ungroupedLinks.forEach((d) => {
 			links.push({
 				name: d.name,
-				href: `${path}/${d.name}`,
+				href: getLink(`${path}/${d.name}`),
 			});
 		});
 
@@ -251,7 +263,7 @@ export function getSidebarLinkGroups(doc: TransformedDoc, path: string) {
 			linkGroups.push({
 				name: name,
 				links: links,
-				href: `${path}/${key}`,
+				href: getLink(`${path}/${key}`),
 			});
 		}
 	}

--- a/src/app/references/components/TDoc/utils/uniqueSlugger.ts
+++ b/src/app/references/components/TDoc/utils/uniqueSlugger.ts
@@ -1,0 +1,23 @@
+export function uniqueSlugger(options: {
+	base: string;
+	isUnique: (slug: string) => boolean;
+}) {
+	const limit = 10;
+	const { base, isUnique } = options;
+
+	// if slug is unique, save it and return
+	if (isUnique(base)) {
+		return base;
+	}
+
+	// build a new slug by adding -n where n is the first number that makes the slug unique
+	let i = 2;
+	while (!isUnique(`${base}-${i}`)) {
+		i++;
+		if (i > limit) {
+			throw new Error(`Too many duplicates found for slug: ${base}`);
+		}
+	}
+
+	return `${base}-${i}`;
+}


### PR DESCRIPTION
This fixes the issue for now - but gotta find a better/stable way to fix this issue

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to ensure unique slugs for documents and sidebar links in the application.

### Detailed summary
- Added `uniqueSlugger` function to generate unique slugs
- Updated slug generation for document names and sidebar links
- Ensured uniqueness for slugs in various components

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->