### PR TITLE
Add explainers for RPC URLs

### DIFF
--- a/src/app/connect/blockchain-api/page.mdx
+++ b/src/app/connect/blockchain-api/page.mdx
@@ -3,7 +3,7 @@ import { TypeScriptIcon, ReactIcon, UnityIcon, DotNetIcon } from "@/icons";
 
 # Blockchain API
 
-Perfomant, reliable and type safe API to read write to any contract on any EVM chain.
+Perfomant, reliable and type safe API to read write to any contract on any EVM chain through our [RPC Edge](/infrastructure/rpc-edge/overview) endpoints.
 
 <Stack>
 <ArticleIconCard

--- a/src/app/infrastructure/rpc-edge/overview/page.mdx
+++ b/src/app/infrastructure/rpc-edge/overview/page.mdx
@@ -1,4 +1,4 @@
-import { DocImage } from "@doc";
+import { Callout, DocImage } from "@doc";
 import { createMetadata } from "@doc";
 import rpcDiagramImage from "./assets/rpc-diagram.svg";
 
@@ -19,6 +19,10 @@ Remote Procedure Call (RPC) Edge provides reliable access to querying data and i
 <DocImage src={rpcDiagramImage} alt="RPC Diagram" />
 
 By default, we provide publicly available RPCs for over 900+ EVM Networks. [View the default RPC endpoints](https://thirdweb.com/dashboard/infrastructure/rpc-edge) for each supported chain.
+
+<Callout variant="info" title="Accessing your RPC URL">
+	To use RPC Edge with other tools like Anvil, take a chain's [public RPC endpoint](https://thirdweb.com/chainlist) and attach your app's client ID from your [account settings](https://thirdweb.com/dashboard/settings/api-keys) `https://<chainId>.rpc.thirdweb.com/<clientId>`.
+</Callout>
 
 #### Features
 

--- a/src/app/typescript/v5/client/page.mdx
+++ b/src/app/typescript/v5/client/page.mdx
@@ -41,3 +41,7 @@ You will need to pass this client to other methods in the SDK. This will allow y
 - download/upload to IPFS
 - access Account Abstraction infrastructure (bundler, paymaster)
 - access other thirdweb services
+
+<Callout variant="info" title="Getting your RPC URL">
+	If you need to access the raw RPC URL, just use thirdweb's default RPC format with your client ID `https://<chainId>.rpc.thirdweb.com/<clientId>`.
+</Callout>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR enhances the Blockchain API documentation by adding information about accessing RPC endpoints through RPC Edge and provides details on how to use RPC URLs with client IDs.

### Detailed summary
- Added information about accessing RPC endpoints through RPC Edge in `src/app/connect/blockchain-api/page.mdx`
- Added a callout with details on using RPC URLs with client IDs in `src/app/typescript/v5/client/page.mdx`
- Updated `src/app/infrastructure/rpc-edge/overview/page.mdx` to include a callout with instructions on accessing RPC URLs with client IDs

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->