### PR TITLE
Added the permission to copy on the iframe tag for export in-app wallets

### DIFF
--- a/src/app/connect/in-app-wallet/how-to/export-private-key/page.mdx
+++ b/src/app/connect/in-app-wallet/how-to/export-private-key/page.mdx
@@ -17,7 +17,7 @@ Allow your users to export the private key for their in-app wallet embedding thi
 
 ```html
 <iframe
-	src="https://embedded-wallet.thirdweb.com/sdk/2022-08-12/embedded-wallet/export?clientId=CLIENT_ID"
+	src="https://embedded-wallet.thirdweb.com/sdk/2022-08-12/embedded-wallet/export?clientId=CLIENT_ID" allow="clipboard-read; clipboard-write"
 />
 ```
 


### PR DESCRIPTION
`allow="clipboard-read; clipboard-write"` added permission on iframe example to copy the private key when embedding the export page

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding `allow="clipboard-read; clipboard-write"` attribute to an iframe element in `page.mdx` for enabling clipboard access.

### Detailed summary
- Added `allow="clipboard-read; clipboard-write"` attribute to the iframe element.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->