### PR TITLE
Default account factory for AA docs

### DIFF
--- a/src/app/connect/account-abstraction/factories/page.mdx
+++ b/src/app/connect/account-abstraction/factories/page.mdx
@@ -1,0 +1,65 @@
+import {
+	Grid,
+	Callout,
+	OpenSourceCard,
+	ArticleIconCard,
+	createMetadata,
+} from "@doc";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { WalletsSmartIcon } from "@/icons";
+
+export const metadata = createMetadata({
+	image: {
+		title: "Account Factories",
+		icon: "wallets",
+	},
+	title: "Deploy your own ERC-4337 Account Factories | thirdweb",
+	description:
+		"Customize the behavior of smart accounts by deploying your own account factory contracts.",
+});
+
+# Account Factories
+
+By default, the SDK uses a global account factory deployed on most chains at address [`0x85e23b94e7F5E9cC1fF78BCe78cfb15B81f0DF00`](https://thirdweb.com/1/0x85e23b94e7F5E9cC1fF78BCe78cfb15B81f0DF00).
+
+The default account factory deploys standard, immutable accounts with the features listed below. However, you can customize the behavior of your apps smart accounts by deploying your own account factory contracts.
+
+## Deploy your own Account Factory contract
+
+You can deploy your own Account Factory via the [explore page](https://thirdweb.com/explore/smart-wallet) or build your own [ERC 4337](https://eips.ethereum.org/EIPS/eip-4337) compatible factory contract using the [Solidity SDK](/contracts/build/base-contracts/erc-4337).
+
+thirdweb offers different kinds of prebuilt account factories:
+
+<Grid>
+	<ArticleIconCard
+		title="Account Factory"
+		href="https://thirdweb.com/thirdweb.eth/AccountFactory"
+		icon={WalletsSmartIcon}
+	/>
+	<ArticleIconCard
+		title="Managed Account Factory"
+		href="https://thirdweb.com/thirdweb.eth/ManagedAccountFactory"
+		icon={WalletsSmartIcon}
+	/>
+</Grid>
+
+#### Account Factories comparison
+
+| Factory Type                                                         | Upgradeability                                              | Expected Usage                                                                                                                                                                                 |
+| -------------------------------------------------------------------- | ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`Standard`](https://thirdweb.com/thirdweb.eth/AccountFactory)       | Non-upgradeable                                             | Developer wants to issue simple smart accounts to their users. They do not anticipate that users wallets will need any feature upgrades.                                                       |
+| [`Managed`](https://thirdweb.com/thirdweb.eth/ManagedAccountFactory) | Account upgrades controlled centrally by the app developer. | Developer wants to issue smart accounts to their users. They do anticipate feature upgrades to user wallets, and want to push upgrades to user wallets for seamless/invisible UX for upgrades. |
+
+#### Account comparison
+
+|                                                     | Simple                     | Managed                                  |
+| --------------------------------------------------- | -------------------------- | ---------------------------------------- |
+| Contracts                                           | `AccountFactory` `Account` | `ManagedAccountFactory` `ManagedAccount` |
+| ERC-4337 Compatible                                 | ✅                         | ✅                                       |
+| Can hold native ERC-20, ERC-721 and ERC-1155 Tokens | ✅                         | ✅                                       |
+| Multi-signer                                        | ✅                         | ✅                                       |
+| Execute transactions in Batches                     | ✅                         | ✅                                       |
+| Is the Account Upgradeable                          | ❌                         | ✅                                       |
+| Who controls upgrades (?)                           | n/a                        | Admin of the account factory.            |
+
+To learn more about each factory and their respective account implementations, read our [smart contract deep dive](https://blog.thirdweb.com/smart-contract-deep-dive-building-smart-wallets-for-individuals-and-teams/).

--- a/src/app/connect/account-abstraction/get-started/page.mdx
+++ b/src/app/connect/account-abstraction/get-started/page.mdx
@@ -4,6 +4,8 @@ import {
 	OpenSourceCard,
 	ArticleIconCard,
 	createMetadata,
+	Steps,
+	Step,
 } from "@doc";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { WalletsSmartIcon } from "@/icons";
@@ -24,32 +26,12 @@ Getting started to add ERC-4337 compatible smart accounts to your application ea
 
 Once set, your application will:
 
-- Let users **connect to their smart account** using any personal wallet, including email and local wallets for easy onboarding.
+- Let users **connect to their smart account** using any personal wallet, including in-app wallets for easy onboarding.
 - Automatically **deploy individual account contracts** for your users when they do their first onchain transaction.
 - **Handle all transaction gas costs** via the thirdweb paymaster.
 
-## 1. Deploy an account factory contract
-
-Deployable via the [explore page](https://thirdweb.com/explore/smart-wallet) or build your own [ERC 4337](https://eips.ethereum.org/EIPS/eip-4337) compatible factory contract using the [Solidity SDK](/contracts/build/base-contracts/erc-4337).
-
-thirdweb offers different kinds of account factories:
-
-<Grid>
-	<ArticleIconCard
-		title="Account Factory"
-		href="https://thirdweb.com/thirdweb.eth/AccountFactory"
-		icon={WalletsSmartIcon}
-	/>
-	<ArticleIconCard
-		title="Managed Account Factory"
-		href="https://thirdweb.com/thirdweb.eth/ManagedAccountFactory"
-		icon={WalletsSmartIcon}
-	/>
-</Grid>
-
-Read about the differences between the account factory types [here](/connect/account-abstraction/how-it-works).
-
-## 2. Get a free API key
+<Steps>
+<Step title="Get a free API key">
 
 You will require an API key to use thirdweb's infrastructure services such as the bundler and paymaster.
 
@@ -59,19 +41,15 @@ The API key lets you access thirdweb's bundler and paymaster infrastructure, whi
 
 Learn more about creating an API key and restricting which contracts the smart account can interact with [here](/api-keys).
 
-## 3. Connect smart accounts in your application
+</Step>
+<Step title="Connect smart accounts in your application">
 
-Use the following code to integrate account abstraction into your apps. This will:
+Use the following code to integrate account abstraction into your apps.
 
-- Connect your users to their smart account based on their personal wallet (can be any EOA wallet such as in-app wallet or metamask).
-- Automatically deploy the individual account contracts for your users when they do their first onchain transaction.
-- Handle all transaction gas costs via the thirdweb paymaster.
-- Select your deployed account factory and client ID to use the thirdweb infrastructure.
+<Callout title="Sponsored transactions" variant="info">
 
-<Callout title="Galess transactions" variant="info">
-
-To set up gasless transactions, set the `gasless` option to `true` in the smart account configuration.
-All transactions performed with the smart account will then be gasless.
+To set up sponsored transactions, set the `sponsorGas` option to `true` in the smart account configuration.
+All transactions performed with the smart account will then be sponsored by your application. Testnet transactions are free, but you need a valid credit card on file for mainnet transactions.
 
 </Callout>
 
@@ -100,8 +78,7 @@ return (
 	    client={client}
 	    accountAbstraction={{
 			chain: sepolia, // the chain where your smart accounts will be or is deployed
-            factoryAddress: "0x...", // your deployed factory address
-            gasless: true // enable or disable gasless transactions
+            sponsorGas: true // enable or disable sponsored transactions
         }}
 	  />
     </ThirdwebProvider>
@@ -123,8 +100,7 @@ function App() {
 		client,
 		accountAbstraction: {
 			chain: sepolia, // the chain where your smart accounts will be or is deployed
-			factoryAddress: "0x...", // your deployed factory address
-			gasless: true, // enable or disable gasless transactions
+			sponsorGas: true, // enable or disable sponsored transactions
 		},
 	});
 
@@ -152,6 +128,7 @@ function App() {
 ```ts
 import { createThirdwebClient } from "thirdweb";
 import { inAppWallet, smartWallet } from "thirdweb/wallets";
+import { sepolia } from "thirdweb/chains";
 
 const client = createThirdwebClient({
 	clientId,
@@ -165,10 +142,9 @@ const personalAccount = await personalWallet.connect({
 });
 // Then, create and connect the Smart wallet
 const wallet = smartwallet({
-	chain: "sepolia", // the chain where your smart wallet will be or is deployed
-	factoryAddress: "0x...", // your own deployed account factory address
+	chain: sepolia, // the chain where your smart wallet will be or is deployed
 	clientId: "YOUR_CLIENT_ID", // or use secretKey for backend/node scripts
-	gasless: true, // enable or disable gasless transactions
+	sponsorGas: true, // enable or disable sponsored transactions
 });
 const smartAccount = await wallet.connect({
 	client,
@@ -204,36 +180,64 @@ string address = await sdk.wallet.Connect(connection);
 </TabsContent>
 </Tabs>
 
-### Demos
+</Step>
+<Step title="Executing Transactions with Smart Accounts">
 
-Learn by example with these open-source demos:
-
-<OpenSourceCard
-	title="Account Abstraction Demos"
-	description="A reference implementation to create and interact with smart accounts."
-	href={"https://github.com/thirdweb-example/account-abstraction"}
-/>
-
-## 4. Executing Transactions with Smart Accounts
-
-Once setup, you can use the thirdweb [TypeScript](/typescript/latest), [React](/react/latest), [React Native](/react-native/latest)
-and [Unity SDKs](/unity) to deploy contracts, perform transactions, and manipulate wallets like any other wallet.
+Once setup, you can use the Connect [TypeScript](/typescript/latest), [React](/react/latest) and [Unity SDKs](/unity) to deploy contracts, perform transactions, and manipulate smart accounts like any other wallet.
 
 <Tabs defaultValue="react">
 
 <TabsList>
-	<TabsTrigger value="react">React</TabsTrigger>
-	<TabsTrigger value="react-native">React Native</TabsTrigger>
+	<TabsTrigger value="ui">UI Component</TabsTrigger>
+	<TabsTrigger value="react">React Hook</TabsTrigger>
 	<TabsTrigger value="typescript">TypeScript</TabsTrigger>
 	<TabsTrigger value="unity">Unity</TabsTrigger>
 </TabsList>
+
+<TabsContent value="ui">
+
+```tsx
+import { getContract } from "thirdweb";
+import { useActiveAccount, TransactionButton } from "thirdweb/react";
+import { mintTo } from "thirdweb/extensions/erc721";
+
+const contract = getContract({ client, chain, address: "0x..." });
+
+// The ThirdwebProvider setup above already handles the connection to the smart account
+// Within the provider, you can use the SDK normally to interact with the blockchain
+export default function MyComponent() {
+	// Get the connected smart account
+	const smartAccount = useActiveAccount();
+	// Mint a new NFT
+	return (
+		<TransactionButton
+			transaction={() => {
+				if (!account) return;
+				return mintTo({
+					contract,
+					to: account.address,
+					nft: {
+						name: "My NFT",
+						description: "My NFT description",
+						image: "https://example.com/image.png",
+					},
+				});
+			}}
+		>
+			Mint NFT
+		</TransactionButton>
+	);
+}
+```
+
+</TabsContent>
 
 <TabsContent value="react">
 
 ```tsx
 import { getContract } from "thirdweb";
-import { useActiveAccount, TransactionButton } from "thirdweb/react";
-import { mintTo } from "thirdweb/extensions/erc721";
+import { useActiveAccount, useSendTransaction } from "thirdweb/react";
+import { mintTo, balanceOf } from "thirdweb/extensions/erc721";
 
 const contract = getContract({ client, chain, address: "0x..." });
 
@@ -242,89 +246,39 @@ const contract = getContract({ client, chain, address: "0x..." });
 export default function MyComponent() {
 	// Get the connected smart account
 	const smartAccount = useActiveAccount();
-	// Fetch owned NFTs
+	// Example read
 	const { data, isLoading } = useReadContract(
-		getOwnedNFTs,
+		balanceOf,
 		{
 			contract,
-			address: smartAccount.address!,
+			owner: smartAccount.address!,
 		},
 		{
 			enabled: !!smartAccount,
 		},
 	);
+	// Example write
+	const { mutate: sendTransaction, isPending } = useSendTransaction();
+	const mint = () => {
+		sendTransaction({
+			transaction: mintTo({
+				contract,
+				to: smartAccount.address,
+				nft: {
+					name: "My NFT",
+					description: "My NFT description",
+					image: "https://example.com/image.png",
+				},
+			}),
+		});
+	};
 	// Mint a new NFT
-	return (
-		<TransactionButton
-			transaction={() => {
-				if (!account) return;
-				return mintTo({
-					contract,
-					to: account.address,
-					nft: {
-						name: "My NFT",
-						description: "My NFT description",
-						image: "https://example.com/image.png",
-					},
-				});
-			}}
-		>
-			Mint NFT
-		</TransactionButton>
-	);
+	return <button onClick={mint}>Mint NFT</button>;
 }
 ```
 
 </TabsContent>
 
-<TabsContent value="react-native">
-
-```tsx
-import { getContract } from "thirdweb";
-import { useActiveAccount, TransactionButton } from "thirdweb/react";
-import { mintTo } from "thirdweb/extensions/erc721";
-
-const contract = getContract({ client, chain, address: "0x..." });
-
-// The ThirdwebProvider setup above already handles the connection to the smart account
-// Within the provider, you can use the SDK normally to interact with the blockchain
-export default function MyComponent() {
-	// Get the connected smart account
-	const smartAccount = useActiveAccount();
-	// Fetch owned NFTs
-	const { data, isLoading } = useReadContract(
-		getOwnedNFTs,
-		{
-			contract,
-			address: smartAccount.address!,
-		},
-		{
-			enabled: !!smartAccount,
-		},
-	);
-	// Mint a new NFT
-	return (
-		<TransactionButton
-			transaction={() => {
-				if (!account) return;
-				return mintTo({
-					contract,
-					to: account.address,
-					nft: {
-						name: "My NFT",
-						description: "My NFT description",
-						image: "https://example.com/image.png",
-					},
-				});
-			}}
-		>
-			Mint NFT
-		</TransactionButton>
-	);
-}
-```
-
-</TabsContent>
 <TabsContent value="typescript">
 
 ```ts
@@ -376,3 +330,16 @@ public async void MintNFT()
 
 </TabsContent>
 </Tabs>
+
+</Step>
+</Steps>
+
+### Demos
+
+Learn by example with these open-source demos:
+
+<OpenSourceCard
+	title="Account Abstraction Demos"
+	description="A reference implementation to create and interact with smart accounts."
+	href={"https://github.com/thirdweb-example/account-abstraction"}
+/>

--- a/src/app/connect/account-abstraction/guides/react/page.mdx
+++ b/src/app/connect/account-abstraction/guides/react/page.mdx
@@ -18,28 +18,6 @@ By using the [wallet SDK](/references/wallets/latest) alongside the [React SDK](
 
 <Steps>
 
-<Step title="Deploy an Account Factory">
-
-Deployable via the [explore page](https://thirdweb.com/explore/smart-wallet) or build your own [ERC 4337](https://eips.ethereum.org/EIPS/eip-4337) compatible factory contract using the [Solidity SDK](/contracts/build/overview).
-
-thirdweb offers the following three different kinds of account factories:
-
-<Grid>
-	<ArticleIconCard
-		title="Account Factory"
-		href="https://thirdweb.com/thirdweb.eth/AccountFactory"
-		icon={WalletsSmartIcon}
-	/>
-	<ArticleIconCard
-		title="Managed Account Factory"
-		href="https://thirdweb.com/thirdweb.eth/ManagedAccountFactory"
-		icon={WalletsSmartIcon}
-	/>
-</Grid>
-
-Read about the differences between the three smart account types [here](/account-abstraction/how-it-works).
-
-</Step>
 <Step title="Create an API key">
 
 To use the bundler and paymaster, you must create an API key and a billing account.
@@ -47,7 +25,7 @@ To use the bundler and paymaster, you must create an API key and a billing accou
 To create an API Key:
 
 - Head to the settings page in the dashboard and click the **API Keys** tab.
-- Click on **Create API Key**:
+- Click on **Create API Key**.
 - Follow the steps to create your API key.
 
 To use account abstraction infrastructure on mainnet you will also need to [create an account and add a payment method](https://thirdweb.com/dashboard/settings/billing).
@@ -87,8 +65,7 @@ function App() {
 				client={client}
 				accountAbstraction={{
 					chain: sepolia,
-					factoryAddress: "your-factory-address",
-					gasless: true,
+					sponsorGas: true,
 				}}
 			/>
 		</div>
@@ -115,8 +92,7 @@ function Example() {
 		client,
 		accountAbstraction: {
 			chain: sepolia,
-			factoryAddress: "your-factory-address",
-			gasless: true,
+			sponsorGas: true,
 		},
 	});
 

--- a/src/app/connect/account-abstraction/guides/typescript/page.mdx
+++ b/src/app/connect/account-abstraction/guides/typescript/page.mdx
@@ -24,27 +24,6 @@ In this guide, we will be using the wallet SDK to create a Node script but the l
 If you are working in a React environment, you are recommended to follow [this guide](/connect/account-abstraction/guides/react).
 
 <Steps>
-    <Step title="Deploy an Account Factory">
-
-Deployable via the [explore page](https://thirdweb.com/explore/smart-wallet) or build your own [ERC 4337](https://eips.ethereum.org/EIPS/eip-4337) compatible factory contract using the [Solidity SDK](/contracts/build/base-contracts/erc-4337).
-thirdweb offers the following three different kinds of account factories:
-
-<Grid>
-	<ArticleIconCard
-		title="Account Factory"
-		href="https://thirdweb.com/thirdweb.eth/AccountFactory"
-		icon={WalletsSmartIcon}
-	/>
-	<ArticleIconCard
-		title="Managed Account Factory"
-		href="https://thirdweb.com/thirdweb.eth/ManagedAccountFactory"
-		icon={WalletsSmartIcon}
-	/>
-</Grid>
-
-Read about the differences between the three factory types [here](/connect/account-abstraction/how-it-works).
-
-</Step>
 <Step title="Create an API key">
 
 To use the bundler and paymaster, you must create an API key and a billing account.
@@ -52,7 +31,7 @@ To use the bundler and paymaster, you must create an API key and a billing accou
 To create an API Key:
 
 - Head to the settings page in the dashboard and click the **API Keys** tab.
-- Click on **Create API Key**:
+- Click on **Create API Key**.
 - Follow the steps to create your API key.
 
 To use account abstraction infrastructure on mainnet you will also need to [create an account and add a payment method](https://thirdweb.com/dashboard/settings/billing).
@@ -105,21 +84,18 @@ Now, let's create a smart account using the SmartWallet class from the `@thirdwe
 To do this, we need to pass a `SmartWalletConfig` object to the constructor. This object contains the following properties:
 
 - `chain`: the chain that the smart account will be deployed on.
-- `factoryAddress`: the address of the account factory contract.
-- `gasless`: whether the smart account should have sponsored transactions or not.
+- `sponsorGas`: whether the smart account should have sponsored transactions or not.
 
 Once we have created the config and instantiated the `SmartWallet` class, we can connect the personal wallet to the smart account using the `connect` method.
 
 ```typescript
 // Configure the smart wallet
-const config = {
+const wallet = smartWallet({
 	chain: sepolia,
-	factoryAddress: "0x...", // your factory address
-	gasless: true,
-};
+	sponsorGas: true,
+});
 
 // Connect the smart wallet
-const wallet = smartWallet(config);
 const smartAccount = await wallet.connect({
 	client,
 	personalAccount,
@@ -174,7 +150,7 @@ bun index.ts
 
 As you can see in the terminal output, upon claiming the token, the smart account is deployed. This is because smart account contracts are deployed when the first transaction is initiated.
 
-We have successfully deployed a smart account using our factory contract and claimed an ERC20 token!
+We have successfully deployed a smart account and claimed an ERC20 token!
 
 </Step>
 <Step title="Conclusion">

--- a/src/app/connect/account-abstraction/how-it-works/page.mdx
+++ b/src/app/connect/account-abstraction/how-it-works/page.mdx
@@ -36,29 +36,9 @@ This smart account is unlocked by a 'key' - a personal account. This key can be 
 
 ## Account Factories
 
-In order to issue smart accounts for users, an account factory contract must be deployed.
-This factory contract is responsible for deploying individual user contracts when required and comes in two different flavors.
-
-#### Types of Account and Account Factory
-
-| Factory Type                                                         | Upgradeability                                              | Expected Usage                                                                                                                                                                                 |
-| -------------------------------------------------------------------- | ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`Simple`](https://thirdweb.com/thirdweb.eth/AccountFactory)         | Non-upgradeable                                             | Developer wants to issue simple smart accounts to their users. They do not anticipate that users wallets will need any feature upgrades.                                                       |
-| [`Managed`](https://thirdweb.com/thirdweb.eth/ManagedAccountFactory) | Account upgrades controlled centrally by the app developer. | Developer wants to issue smart accounts to their users. They do anticipate feature upgrades to user wallets, and want to push upgrades to user wallets for seamless/invisible UX for upgrades. |
-
-### Account Type Feature Comparison
-
-|                                                     | Simple                     | Managed                                  |
-| --------------------------------------------------- | -------------------------- | ---------------------------------------- |
-| Contracts                                           | `AccountFactory` `Account` | `ManagedAccountFactory` `ManagedAccount` |
-| ERC-4337 Compatible                                 | ✅                         | ✅                                       |
-| Can hold native ERC-20, ERC-721 and ERC-1155 Tokens | ✅                         | ✅                                       |
-| Multi-signer                                        | ✅                         | ✅                                       |
-| Execute transactions in Batches                     | ✅                         | ✅                                       |
-| Is the Account Upgradeable                          | ❌                         | ✅                                       |
-| Who controls upgrades (?)                           | n/a                        | Admin of the account factory.            |
-
-To learn more about each factory and their respective account implementations, read our [smart contract deep dive](https://blog.thirdweb.com/smart-contract-deep-dive-building-smart-wallets-for-individuals-and-teams/).
+In order to issue smart accounts for users, an account factory contract must be used.
+This factory contract is responsible for deploying individual user contracts when required.
+The SDK provides a global factory ready to use, but you can also deploy your own factory.
 
 ## Terminology
 

--- a/src/app/connect/account-abstraction/infrastructure/page.mdx
+++ b/src/app/connect/account-abstraction/infrastructure/page.mdx
@@ -23,25 +23,29 @@ You can configure your client ID to restrict interactions only with your own con
 
 With a thirdweb API key, you get access to bundler and paymaster infrastructure on the following chains:
 
-| Chain             | Mainnet | Testnet              |
-| ----------------- | ------- | -------------------- |
-| Ethereum          | ✅      | ✅ (goerli, sepolia) |
-| Polygon           | ✅      | ✅ (amoy)    |
-| Arbitrum  (one, nova)         | ✅      | ✅ (goerli, sepolia) |
-| Optimism          | ✅      | ✅                   |
-| Gnosis            | ✅      | ✅                   |
-| Linea             | ✅      | ✅                   |
-| Base              | ✅      | ✅ (goerli, sepolia) |
-| Avalanche C-Chain | ✅      | ✅                   |
-| Scroll            | ✅      | ✅                   |
-| Celo              | ✅      | ✅                   |
-| Binance           | ✅      | ✅                   |
-| Xai Orbit         | ✅      | ✅                   |
-| Mode              | ✅      | ✅                   |
-| Zora              | ✅      | ✅                   |
-| Fraxtal           | ✅      | ✅                   |
-| Lisk           | ✅      | ❌                   |
-| Taiko           | ✅      | ❌                   |
+| Chain                | Mainnet | Testnet |
+| -------------------- | ------- | ------- |
+| Ethereum             | ✅      | ✅      |
+| Polygon              | ✅      | ✅      |
+| Arbitrum (one, nova) | ✅      | ✅      |
+| Optimism             | ✅      | ✅      |
+| Gnosis               | ✅      | ✅      |
+| Linea                | ✅      | ✅      |
+| Base                 | ✅      | ✅      |
+| Avalanche C-Chain    | ✅      | ✅      |
+| Scroll               | ✅      | ✅      |
+| Celo                 | ✅      | ✅      |
+| Binance              | ✅      | ✅      |
+| Xai Orbit            | ✅      | ✅      |
+| Mode                 | ✅      | ✅      |
+| Zora                 | ✅      | ✅      |
+| Fraxtal              | ✅      | ✅      |
+| Lisk                 | ✅      | ❌      |
+| Taiko                | ✅      | ❌      |
+| Degen                | ✅      | ❌      |
+| Mantle               | ✅      | ❌      |
+| Ancient8             | ✅      | ✅      |
+| Blast                | ❌      | ✅      |
 
 To support a chain not listed, [contact us](https://thirdweb.typeform.com/to/Q93CVgUc?typeform-source=thirdweb-www-git-mariano-ftd-1670.thirdweb-preview.com).
 
@@ -53,8 +57,7 @@ pass the `bundlerUrl` the `SmartWalletOptions` overrides:
 ```ts
 const config: SmartWalletOptions = {
 	chain,
-	factoryAddress,
-	gasless,
+	sponsorGas: true,
 	overrides: {
 		bundlerUrl: "your-bundler-url",
 	},
@@ -68,8 +71,7 @@ You can also provide an entirely custom paymaster logic by providing a `paymaste
 ```ts
 const config: SmartWalletOptions = {
 	chain,
-	factoryAddress,
-	gasless,
+	sponsorGas: true,
 	overrides: {
 		paymaster: async (userOp: UserOperation) => {
 			// your custom paymaster logic

--- a/src/app/connect/in-app-wallet/how-to/enable-gasless/page.mdx
+++ b/src/app/connect/in-app-wallet/how-to/enable-gasless/page.mdx
@@ -90,9 +90,8 @@ export default function App() {
 				client={client}
 				wallets={wallets}
 				accountAbstraction={{
-					factoryAddress: "0x...", // your factory address
 					chain: sepolia, // your chain
-					gasless: true,
+					sponsorGas: true,
 				}}
 			/>
 		</ThirdwebProvider>
@@ -102,6 +101,4 @@ export default function App() {
 
 This will create an in-app wallet and a smart account for the user. The smart account will be initialized with the in-app wallet as the owner.
 
-Pass your deployed `factoryAddress` to the `accountAbstraction` prop. This will allow the smart account to be be deployed only when the user sends their first transaction.
-
-You can sponsor transactions simply by passing `gasless: true` to the `accountAbstraction` prop. This will allow the smart account to send transactions without the user needing to hold any ETH.
+You can sponsor transactions simply by passing `sponsrGas: true` to the `accountAbstraction` prop. This will allow the smart account to send transactions without the user needing to hold any ETH.

--- a/src/app/connect/sidebar.tsx
+++ b/src/app/connect/sidebar.tsx
@@ -1,4 +1,4 @@
-import { SideBar } from "@/components/Layouts/DocLayout";
+import type { SideBar } from "@/components/Layouts/DocLayout";
 import {
 	WalletsAuthIcon,
 	WalletsConnectIcon,
@@ -164,6 +164,10 @@ export const sidebar: SideBar = {
 				{
 					name: "Batching Transactions",
 					href: `${aAslug}/batching-transactions`,
+				},
+				{
+					name: "Account Factories",
+					href: `${aAslug}/factories`,
 				},
 				{
 					name: "Bundler & Paymaster",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the account abstraction feature in the app. 

### Detailed summary
- Added "Account Factories" link in the sidebar
- Updated `gasless` to `sponsorGas` for sponsoring transactions
- Updated API key creation instructions
- Updated smart account creation logic and configurations

> The following files were skipped due to too many changes: `src/app/connect/account-abstraction/how-it-works/page.mdx`, `src/app/connect/account-abstraction/factories/page.mdx`, `src/app/connect/account-abstraction/get-started/page.mdx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->