### PR TITLE
deprecated python and go references

### DIFF
--- a/src/app/account/api-keys/use/page.mdx
+++ b/src/app/account/api-keys/use/page.mdx
@@ -4,7 +4,7 @@ import { createMetadata } from "@doc";
 export const metadata = createMetadata({
 	title: "Using thirdweb API Key",
 	description:
-		"How to use thirdweb API key in TypeScript, React, Unity, Python, and Go.",
+		"How to use thirdweb API key in TypeScript, React, and Unity.",
 	image: {
 		title: "Using thirdweb API Key",
 		icon: "thirdweb",
@@ -19,8 +19,6 @@ export const metadata = createMetadata({
 	<TabsTrigger value="typescript">TypeScript</TabsTrigger>
 	<TabsTrigger value="react">React</TabsTrigger>
 	<TabsTrigger value="unity">Unity</TabsTrigger>
-	<TabsTrigger value="python">Python</TabsTrigger>
-	<TabsTrigger value="go">Go</TabsTrigger>
 </TabsList>
 
 <TabsContent value='typescript'>
@@ -76,61 +74,4 @@ ThirdwebSDK sdk = new ThirdwebSDK("goerli", 5, new ThirdwebSDK.Options()
 
 </TabsContent>
 
-<TabsContent value="python">
-
-When using the Python SDK, you can use the secret key to instantiate the SDK:
-
-```python
-from thirdweb import ThirdwebSDK
-from thirdweb.types import SDKOptions
-from dotenv.main import load_dotenv
-import os
-
-  load_dotenv()
-  secret_key = os.environ['SECRET_KEY']
-  private_key = os.environ['PRIVATE_KEY']
-
-  sdk = ThirdwebSDK.from_private_key(private_key, "<chain_id>", SDKOptions(secret_key=secret_key))
-```
-
-</TabsContent>
-
-<TabsContent value="go" >
-
-When using the GO SDK, you can use the secret key to instantiate the SDK:
-
-```go
-package main
-
-import (
-    "fmt"
-
-    "github.com/thirdweb-dev/go-sdk/v2/thirdweb"
-)
-
-func main() {
-    // Your secret key from the thirdweb api keys dashboard
-    secretKey := "..."
-
-    // Creates a new SDK instance to get read-only data for your contracts, you can pass:
-    // - a chain name (mainnet, rinkeby, goerli, polygon, avalanche, fantom)
-    // - a custom RPC URL
-    sdk, err := thirdweb.NewThirdwebSDK("<chain_id>", &thirdweb.SDKOptions{
-      SecretKey: secretKey,
-    })
-    if err != nil {
-      panic(err)
-  }
-
-    // Now we can interact with the SDK, like displaying the connected chain ID
-    chainId, err := sdk.GetChainID()
-    if err != nil {
-      panic(err)
-    }
-
-    fmt.Println("New SDK instance create onchain", chainId)
-}
-```
-
-</TabsContent>
 </Tabs>

--- a/src/app/cli/install/page.mdx
+++ b/src/app/cli/install/page.mdx
@@ -24,11 +24,6 @@ This command will automatically detect the type of project you are working on an
     - **React**: [`@thirdweb/react`](/react/latest), [`@thirdweb/sdk`](/typescript/latest) and [`ethers` v5](https://docs.ethers.org/v5/)
     - **React Native**: [`@thirdweb/react-native`](/react-native/latest), [`@thirdweb/react-native-compat`](/react-native/latest) and [`ethers` v5](https://docs.ethers.org/v5/)
     - **Other**: [`@thirdweb/sdk`](/typescript/latest) and [`ethers` v5](https://docs.ethers.org/v5/)
-- **Python:**
-  - **Smart contract projects**: [`thirdweb-dev/contracts`](/python)
-  - **App projects**: [`thirdweb-sdk`](/python)
-- **Go:**
-  - **App projects**: [`github.com/thirdweb-dev/go-sdk/v2`](/go)
 
 If any thirdweb package _(or Ethers)_ is already installed, they are updated to the latest compatible version.
 

--- a/src/app/contracts/explore/pre-built-contracts/nft-drop/page.mdx
+++ b/src/app/contracts/explore/pre-built-contracts/nft-drop/page.mdx
@@ -160,8 +160,6 @@ Optionally, users may choose to hide their NFT image and metadata from users bef
 	<TabsTrigger value="typescript">TypeScript</TabsTrigger>
 	<TabsTrigger value="react">React</TabsTrigger>
 	<TabsTrigger value="react-native">React Native</TabsTrigger>
-	<TabsTrigger value="python">Python</TabsTrigger>
-	<TabsTrigger value="go">Go</TabsTrigger>
 </TabsList>
 
 <TabsContent value="typescript">
@@ -192,38 +190,6 @@ const sdk = useSDK(
 		primary_sale_recipient: "<wallet_address>",
 	}),
 );
-```
-
-</TabsContent>
-
-<TabsContent value="python">
-
-```python
-from thirdweb.types.settings.metadata import NFTDropContractMetadata
-
-metadata = NFTDropContractMetadata(
-	name="<your_contract_name>",
-	primary_sale_recipient="<wallet_address>",
-	seller_fee_basis_points=500, # 5% royalty fee
-	fee_recipient="<wallet_address>",
-	platform_fee_basis_points=10, # 0.1% platform fee
-	platform_fee_recipient="<wallet_address>",
-)
-
-sdk.deployer.deploy_nft_drop(metadata)
-```
-
-</TabsContent>
-
-<TabsContent value="go">
-
-```go
-address, err := sdk.Deployer.DeployNFTDrop(
-	context.Background(),
-		&thirdweb.DeployNFTDropMetadata{
-				Name: "<your_contract_name>",
-		}
-)
 ```
 
 </TabsContent>

--- a/src/app/contracts/interact/overview/page.mdx
+++ b/src/app/contracts/interact/overview/page.mdx
@@ -19,7 +19,7 @@ The Contract SDK removes the need to manage complex, repetitive logic, allowing 
 #### Features
 
 - **Extension-Driven Framework:** The SDK uses an extension-driven approach, automatically recognizing and enabling functionality based on common standards that your contract implements like ERC20, ERC721, and ERC1155. The full list of extensions can be found in the Solidity documentation.
-- **Multiple Languages:** SDKs for Unity, TypeScript, React, Python, and GO.
+- **Multiple Languages:** SDKs for Unity, TypeScript, and React.
 - **Any EVM Compatibility:** Designed to operate with any EVM-compatible network.
 - **Cross-Platform Integration:** Suitable for web, mobile, gaming applications and scripting.
 - **High-Level Abstractions:** Simplifies complex contract interactions into easy-to-use APIs.

--- a/src/app/infrastructure/rpc-edge/get-started/page.mdx
+++ b/src/app/infrastructure/rpc-edge/get-started/page.mdx
@@ -29,8 +29,6 @@ Pass in the Client ID and Secret Keys into the application’s configuration.
   <TabsTrigger value="react">React</TabsTrigger>
   <TabsTrigger value="react-native">React Native</TabsTrigger>
   <TabsTrigger value="typescript">TypeScript</TabsTrigger>
-  <TabsTrigger value="python">Python</TabsTrigger>
-  <TabsTrigger value="go">Go</TabsTrigger>
 </TabsList>
 
 <TabsContent value="react">
@@ -79,34 +77,6 @@ When using the Typescript SDK for frontend applications, use the client id:
 const readOnlySdk = new ThirdwebSDK("<chain_id>", {
 	clientId: "<your_client_id>",
 });
-```
-
-</TabsContent>
-
-<TabsContent value="python">
-  When using the Python SDK, use the secret key to instantiate the SDK:
-
-```python
-sdk = ThirdwebSDK.from_private_key(
-    <private_key>,
-    "<chain_id>",
-    SDKOptions(secret_key=<your_secret_key>)
-)
-```
-
-</TabsContent>
-
-<TabsContent value="go">
-When using the GO SDK, you can use the secret key to instantiate the SDK:
-
-```go
-func main() {
-	// Your secret key from the thirdweb api keys dashboard
-	secretKey := "<your_secret_key"
-	sdk, err := thirdweb.NewThirdwebSDK("<chain_id>", &thirdweb.SDKOptions{
-		SecretKey: <your_secret_key>,
-	})
-}
 ```
 
 </TabsContent>

--- a/src/app/infrastructure/storage/how-to-use-storage/upload-files-to-ipfs/page.mdx
+++ b/src/app/infrastructure/storage/how-to-use-storage/upload-files-to-ipfs/page.mdx
@@ -87,8 +87,6 @@ npx thirdweb upload directory_name
 		<TabsTrigger value="react">React</TabsTrigger>
 		<TabsTrigger value="react-native">React Native</TabsTrigger>
         <TabsTrigger value="typescript">TypeScript</TabsTrigger>
-		<TabsTrigger value="python">Python</TabsTrigger>
-        <TabsTrigger value="go">Go</TabsTrigger>
 	</TabsList>
 	<TabsContent value="react">
     ```jsx
@@ -199,38 +197,5 @@ npx thirdweb upload directory_name
         const data = await storage.downloadJSON(uri);
     ```
     </TabsContent>
-     <TabsContent value="python">
-     ```python
-        from thirdweb import ThirdwebSDK
-        sdk = ThirdwebSDK("goerli")
-        metadata = {
-        "name": "NFT",
-        "image": "ipfs://..."
-        }
-        uri = sdk.storage.upload(metadata)
-    ```
-
-</TabsContent>
-      <TabsContent value="go">
-      ```go
-        package main
-
-        import (
-            "context"
-            "github.com/thirdweb-dev/go-sdk/v2/thirdweb"
-        )
-
-        func main() {
-            sdk, _ := thirdweb.NewThirdwebSDK("goerli", nil)
-
-            metadata := map[string]interface{}{
-            "name": "NFT",
-            "image": "ipfs://..."
-            }
-            uri, _ := sdk.Storage.Upload(context.Background(), metadata, "", "")
-        }
-    ```
-
-</TabsContent>
 
 </Tabs>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,8 +18,6 @@ import { CodeIcon } from "lucide-react";
 import {
 	TypeScriptIcon,
 	ReactIcon,
-	// PythonIcon,
-	// GoIcon,
 	UnityIcon,
 	DotNetIcon,
 	SolidityIcon,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to remove Python and Go support for thirdweb SDKs, update content related to these languages, and streamline the SDK offerings. 

### Detailed summary
- Removed Python and Go support for thirdweb SDKs in various files
- Updated content and examples related to Python and Go in multiple files

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->