### PR TITLE
Remove v4 pages from sitemap

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -16,11 +16,11 @@ module.exports = {
 	},
 	exclude: [
 		// exclude v4 stuff
-		"/v4",
-		"/react-native/v0",
-		"/wallet-sdk",
-		"/storage-sdk",
+		"*/v4*",
+		"*/react-native/v0*",
+		"/wallet-sdk*",
+		"/storage-sdk*",
 		// exclude styleguide
-		"/styleguide",
+		"/styleguide*",
 	],
 };

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -14,4 +14,13 @@ module.exports = {
 			},
 		],
 	},
+	exclude: [
+		// exclude v4 stuff
+		"/v4",
+		"/react-native/v0",
+		"/wallet-sdk",
+		"/storage-sdk",
+		// exclude styleguide
+		"/styleguide",
+	],
 };


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on excluding specific paths from the sitemap generation in the Next.js project.

### Detailed summary
- Excludes paths containing `/v4*`, `/react-native/v0*`, `/wallet-sdk*`, `/storage-sdk*`, and `/styleguide*` from the sitemap generation in `next-sitemap.config.js`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->