### PR TITLE
Enforce static generation for reference pages ( prod only )

### DIFF
--- a/src/app/references/components/TDoc/PageLayout.tsx
+++ b/src/app/references/components/TDoc/PageLayout.tsx
@@ -100,8 +100,8 @@ export function getTDocPage(options: {
 		const versions = await getVersions();
 
 		const returnVal = await Promise.all(
-			versions.map((version) => {
-				return getDoc(version)
+			versions.map(async (version) => {
+				const paths = await getDoc(version)
 					.then((doc) => fetchAllSlugs(doc))
 					.then((slugs) => {
 						return [
@@ -114,10 +114,12 @@ export function getTDocPage(options: {
 							{ version, slug: [] },
 						];
 					});
+				return paths;
 			}),
 		);
 
-		return returnVal.flat();
+		const paths = returnVal.flat();
+		return paths;
 	}
 
 	async function generateMetadata(props: PageProps): Promise<Metadata> {
@@ -144,7 +146,11 @@ export function getTDocPage(options: {
 	}
 
 	return {
-		dynamicParams: false,
+		// force-static on dev and previews to lower the build time and vercel cost
+		dynamic: (process.env.VERCEL_ENV !== "preview" &&
+		process.env.VERCEL_ENV !== "development"
+			? "force-static"
+			: "auto") as "force-static" | "auto",
 		default: Page,
 		generateStaticParams,
 		generateMetadata,

--- a/src/app/references/react-native/[version]/[[...slug]]/page.tsx
+++ b/src/app/references/react-native/[version]/[[...slug]]/page.tsx
@@ -14,4 +14,4 @@ const config = getTDocPage({
 export default config.default;
 export const generateStaticParams = config.generateStaticParams;
 export const generateMetadata = config.generateMetadata;
-export const dynamicParams = config.dynamicParams;
+export const dynamic = config.dynamic;

--- a/src/app/references/react/[version]/[[...slug]]/page.tsx
+++ b/src/app/references/react/[version]/[[...slug]]/page.tsx
@@ -14,4 +14,4 @@ const config = getTDocPage({
 export default config.default;
 export const generateStaticParams = config.generateStaticParams;
 export const generateMetadata = config.generateMetadata;
-export const dynamicParams = config.dynamicParams;
+export const dynamic = config.dynamic;

--- a/src/app/references/storage/[version]/[[...slug]]/page.tsx
+++ b/src/app/references/storage/[version]/[[...slug]]/page.tsx
@@ -14,4 +14,4 @@ const config = getTDocPage({
 export default config.default;
 export const generateStaticParams = config.generateStaticParams;
 export const generateMetadata = config.generateMetadata;
-export const dynamicParams = config.dynamicParams;
+export const dynamic = config.dynamic;

--- a/src/app/references/typescript/[version]/[[...slug]]/page.tsx
+++ b/src/app/references/typescript/[version]/[[...slug]]/page.tsx
@@ -14,4 +14,4 @@ const config = getTDocPage({
 export default config.default;
 export const generateStaticParams = config.generateStaticParams;
 export const generateMetadata = config.generateMetadata;
-export const dynamicParams = config.dynamicParams;
+export const dynamic = config.dynamic;

--- a/src/app/references/wallets/[version]/[[...slug]]/page.tsx
+++ b/src/app/references/wallets/[version]/[[...slug]]/page.tsx
@@ -14,4 +14,4 @@ const config = getTDocPage({
 export default config.default;
 export const generateStaticParams = config.generateStaticParams;
 export const generateMetadata = config.generateMetadata;
-export const dynamicParams = config.dynamicParams;
+export const dynamic = config.dynamic;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the `dynamicParams` variable to `dynamic` in multiple files and add logic to set it based on the environment.

### Detailed summary
- Renamed `dynamicParams` to `dynamic` in multiple files
- Added logic to set `dynamic` based on the environment in `getTDocPage` function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->