### PR TITLE
Upgrade `pnpm` to fix vercel build

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,5 +67,5 @@
 		"tailwindcss": "^3.4.3",
 		"typescript": "^5.4.5"
 	},
-	"packageManager": "pnpm@8.9.0"
+	"packageManager": "pnpm@9.1.1"
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `pnpm` package manager to version 9.1.1 in `package.json`.

### Detailed summary
- Updated `pnpm` package manager to version 9.1.1.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->