### PR TITLE
Update page.mdx

### DIFF
--- a/src/app/connect/in-app-wallet/custom-auth/configuration/page.mdx
+++ b/src/app/connect/in-app-wallet/custom-auth/configuration/page.mdx
@@ -154,7 +154,7 @@ const { connect } = useConnect();
 const handlePostLogin = async (jwt: string) => {
 	await connect(() => {
 		const wallet = inAppWallet();
-		wallet.connect({
+		await wallet.connect({
 			client,
 			strategy: "auth_endpoint",
 			// This is the payload that is sent to the auth endpoint


### PR DESCRIPTION
Adding an await before wallet.connect function. If there is no await, this leads to errors

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `page.mdx` file in the in-app-wallet custom auth configuration to use `await` when connecting to the wallet.

### Detailed summary
- Updated `wallet.connect()` to `await wallet.connect()` for asynchronous connection.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->