### PR TITLE
Update page.mdx

### DIFF
--- a/src/app/react-native/v0/installation/page.mdx
+++ b/src/app/react-native/v0/installation/page.mdx
@@ -37,7 +37,7 @@ export const metadata = createMetadata({
 <TabsContent value="cli_project">
 	<InstallTabs
 		npm="npm i ethers@^5 @thirdweb-dev/react-native @thirdweb-dev/react-native-compat node-libs-browser react-native-crypto react-native-randombytes react-native-get-random-values react-native-svg@^13.9.0 react-native-mmkv @react-native-async-storage/async-storage"
-		yarn="yarn add ethers@^5 @thirdweb-dev/react-native @thirdweb-dev/react-native-compat node-libs-browser react-native-crypto react-native-randombytes react-native-get-random-values 'react-native-svg@^13.9.0' react-native-mmkv @react-native-async-storage/async-storage"
+		yarn="yarn add 'ethers@^5' @thirdweb-dev/react-native @thirdweb-dev/react-native-compat node-libs-browser react-native-crypto react-native-randombytes react-native-get-random-values react-native-svg@^13.9.0 react-native-mmkv @react-native-async-storage/async-storage"
 		pnpm="pnpm i ethers@^5 @thirdweb-dev/react-native @thirdweb-dev/react-native-compat node-libs-browser react-native-crypto react-native-randombytes react-native-get-random-values react-native-svg@^13.9.0 react-native-mmkv @react-native-async-storage/async-storage"
 	/>
 


### PR DESCRIPTION
Updated the yarn command to install dependencies for react native using expo. I added strings for ethers because without those yarn can't find ethers also removed strings for react native svg

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the installation script in `page.mdx` for a React Native project by fixing the yarn command for adding the `ethers` package.

### Detailed summary
- Updated the yarn command to correctly add the `ethers@^5` package in the installation script.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->