### PR TITLE
Update redirect for /typescript/latest

### DIFF
--- a/redirects.mjs
+++ b/redirects.mjs
@@ -668,13 +668,13 @@ export const redirects = async () => {
 		// references docs
 		latestReference("react", "v4"),
 		latestReference("react-native", "v0"),
-		latestReference("typescript", "v4"),
+		latestReference("typescript", "v5"),
 		latestReference("wallets", "v2"),
 		latestReference("storage", "v2"),
 		// sdk docs
 		latestSDK("react", "v4"),
 		latestSDK("react-native", "v0"),
-		latestSDK("typescript", "v4"),
+		latestSDK("typescript", "v5"),
 		latestSDK("wallet-sdk", "v2"),
 		latestSDK("storage-sdk", "v2"),
 	];


### PR DESCRIPTION
`/typescript/latest` should redirect to `/typescript/v5` and NOT `/typescript/v4`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version references for `typescript` from v4 to v5.

### Detailed summary
- Updated `typescript` version reference from v4 to v5 in redirects
- Updated `typescript` version reference from v4 to v5 in SDK docs

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->