### PR TITLE
remove extraneous params for passkey auth example

### DIFF
--- a/src/app/connect/in-app-wallet/how-to/build-your-own-ui/page.mdx
+++ b/src/app/connect/in-app-wallet/how-to/build-your-own-ui/page.mdx
@@ -193,7 +193,7 @@ import { inAppWallet, hasStoredPasskey } from "thirdweb/wallets/in-app";
 
 const { connect } = useConnect();
 
-const handleLogin = async (email: string, verificationCode: string) => {
+const handleLogin = async () => {
 	await connect(() => {
 		const wallet = inAppWallet();
 		const hasPasskey = await hasStoredPasskey(client);


### PR DESCRIPTION
Removes `email`/`verificationCode` params in passkey auth example, probably copied and pasted from email example

<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes unused parameters from the `handleLogin` function in `page.mdx`.

### Detailed summary
- Removed `email` and `verificationCode` parameters from `handleLogin` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->