### PR TITLE
Update page.mdx

### DIFF
--- a/src/app/connect/account-abstraction/infrastructure/page.mdx
+++ b/src/app/connect/account-abstraction/infrastructure/page.mdx
@@ -46,6 +46,8 @@ With a thirdweb API key, you get access to bundler and paymaster infrastructure 
 | Mantle               | ✅      | ❌      |
 | Ancient8             | ✅      | ✅      |
 | Blast                | ❌      | ✅      |
+| B3                   | ❌      | ✅      |
+| Plume                | ❌      | ✅      |
 
 To support a chain not listed, [contact us](https://thirdweb.com/contact-us).
 


### PR DESCRIPTION
Added: 
B3 testnet
Plume Testnet

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the page.mdx file in the `account-abstraction` infrastructure folder. It adds support for chains B3 and Plume while removing support for Blast. 

### Detailed summary
- Added support for chains B3 and Plume
- Removed support for Blast

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->