### PR TITLE
fix: correct yarn command from 'yarn install' to 'yarn add'

### DIFF
--- a/src/app/connect/pay/get-started/page.mdx
+++ b/src/app/connect/pay/get-started/page.mdx
@@ -32,7 +32,7 @@ The following guide uses our React SDK. You can also learn how to integrate Pay 
 <Step title="Install the Connect SDK">
 <InstallTabs
 	npm="npm i thirdweb"
-	yarn="yarn install thirdweb"
+	yarn="yarn add thirdweb"
 	pnpm="pnpm i thirdweb"
 />
 </Step>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `yarn` command in the `InstallTabs` component of `page.mdx`.

### Detailed summary
- Updated `yarn` command from `yarn install thirdweb` to `yarn add thirdweb` in `InstallTabs` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->