### PR TITLE
Update page.mdx

### DIFF
--- a/src/app/connect/account-abstraction/infrastructure/page.mdx
+++ b/src/app/connect/account-abstraction/infrastructure/page.mdx
@@ -48,6 +48,8 @@ With a thirdweb API key, you get access to bundler and paymaster infrastructure 
 | Blast                | ❌      | ✅      |
 | B3                   | ❌      | ✅      |
 | Plume                | ❌      | ✅      |
+| Camp Network         | ❌      | ✅      |
+| Vanar                | ❌      | ✅      |
 
 To support a chain not listed, [contact us](https://thirdweb.com/contact-us).
 


### PR DESCRIPTION
Add Camp Network and Vanar testnets for AA support

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the supported chains in the `page.mdx` file for account abstraction.

### Detailed summary
- Added support for `Camp Network` and `Vanar` chains
- Removed support for `B3` and `Plume` chains
- Added a note to contact for supporting additional chains

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->