### PR TITLE
fix: add missing import to doc

### DIFF
--- a/src/app/connect/sign-in/ConnectButton/page.mdx
+++ b/src/app/connect/sign-in/ConnectButton/page.mdx
@@ -44,6 +44,7 @@ On the thirdweb dashboard, navigate to settings to [create an API Key](https://t
 In your application, initialize and add the `ConnectButton` component by passing in your Client Id. 
 
 ```ts
+import { createThirdwebClient } from 'thirdweb'
 import { ThirdwebProvider, ConnectButton } from "thirdweb/react";
 
 const client = createThirdwebClient({ clientId: your_client_id });


### PR DESCRIPTION
The proposal of this PR is to add missing import "createThirdwebClient" from thirdweb package

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new import statement for `createThirdwebClient` in `page.mdx` and makes a minor formatting adjustment.

### Detailed summary
- Added import for `createThirdwebClient`
- Minor formatting adjustment in the file

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->