### PR TITLE
Expand accordion list by default

### DIFF
--- a/src/components/others/Sidebar.tsx
+++ b/src/components/others/Sidebar.tsx
@@ -175,7 +175,7 @@ function DocSidebarCategory(props: {
 		},
 		pathname,
 	);
-	const defaultOpen = !!(hasActiveHref || expanded);
+	const defaultOpen = isCategoryActive || !!(hasActiveHref || expanded);
 
 	const [open, setOpen] = useState(defaultOpen ? true : false);
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the logic for setting the default state of the sidebar to be open based on the active category.

### Detailed summary
- Updated the default state logic in `Sidebar.tsx` to consider the active category for opening the sidebar.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->