### PR TITLE
docs(transaction):Update page.mdx

### DIFF
--- a/src/app/typescript/v5/transactions/send/page.mdx
+++ b/src/app/typescript/v5/transactions/send/page.mdx
@@ -28,13 +28,15 @@ Send a transaction and wait for it to be mined. Useful when you want to block un
 ```ts
 import { sendAndConfirmTransaction } from "thirdweb";
 import { createWallet } from "thirdweb/wallets";
+import { useActiveAccount } from "thirdweb/react";
 
-const wallet = createWallet("io.metamask");
-await wallet.connect();
+//
+const activeAccount = useActiveAccount();
+//
 
 const receipt = await sendAndConfirmTransaction({
 	transaction,
-	wallet,
+	account:activeAccount,
 });
 ```
 


### PR DESCRIPTION
Using the wallet object throws an error `reading address of undefined `. replacing with an account object works.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to replace the usage of `createWallet` and `wallet.connect()` with the new `useActiveAccount` hook for handling active accounts in transaction sending.

### Detailed summary
- Replaced `createWallet` and `wallet.connect()` with `useActiveAccount` hook
- Updated `sendAndConfirmTransaction` to use `activeAccount` instead of `wallet`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->