### PR TITLE
Update page.mdx

### DIFF
--- a/src/app/connect/account-abstraction/infrastructure/page.mdx
+++ b/src/app/connect/account-abstraction/infrastructure/page.mdx
@@ -49,7 +49,16 @@ With a thirdweb API key, you get access to bundler and paymaster infrastructure 
 | B3                   | ❌      | ✅      |
 | Plume                | ❌      | ✅      |
 | Camp Network         | ❌      | ✅      |
-| Vanar                | ❌      | ✅      |
+| Vanar                | ✅      | ✅      |
+| DFK                  | ❌      | ✅      |
+| Form                 | ❌      | ✅      |
+| Cyber                | ✅      | ✅      |
+| Treasure Ruby        | ✅      | ✅      |
+| Redstone             | ✅      | ✅      |
+| Klaytn Cypress       | ✅      | ✅      |
+| OpBNB                | ✅      | ✅      |
+| Nautilus             | ✅      | ✅      | 
+| Fuse                 | ✅      | ✅      |
 
 To support a chain not listed, [contact us](https://thirdweb.com/contact-us).
 

--- a/src/app/connect/account-abstraction/infrastructure/page.mdx
+++ b/src/app/connect/account-abstraction/infrastructure/page.mdx
@@ -50,15 +50,15 @@ With a thirdweb API key, you get access to bundler and paymaster infrastructure 
 | Plume                | ❌      | ✅      |
 | Camp Network         | ❌      | ✅      |
 | Vanar                | ✅      | ✅      |
-| DFK                  | ❌      | ✅      |
+| DFK                  | ✅      | ✅      |
 | Form                 | ❌      | ✅      |
 | Cyber                | ✅      | ✅      |
-| Treasure Ruby        | ✅      | ✅      |
+| Treasure Ruby        | ✅      | ❌      |
 | Redstone             | ✅      | ✅      |
 | Klaytn Cypress       | ✅      | ✅      |
-| OpBNB                | ✅      | ✅      |
-| Nautilus             | ✅      | ✅      | 
-| Fuse                 | ✅      | ✅      |
+| OpBNB                | ✅      | ❌      |
+| Nautilus             | ✅      | ❌      | 
+| Fuse                 | ✅      | ❌      |
 
 To support a chain not listed, [contact us](https://thirdweb.com/contact-us).
 


### PR DESCRIPTION
Update supported chains

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the page content in `page.mdx` for various account abstraction services. It adds, removes, and updates service names.

### Detailed summary
- Updated service names for account abstraction
- Added new services: `DFK`, `Cyber`, `Redstone`, `Klaytn Cypress`
- Removed services: `Treasure Ruby`, `OpBNB`, `Nautilus`, `Fuse`
- Updated status for existing services

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->