### PR TITLE
setup paper redirects

### DIFF
--- a/redirects.mjs
+++ b/redirects.mjs
@@ -40,49 +40,34 @@ const reactRedirects = {
 	"/react/react.usecontractwrite": "/references/react/v4/useContractWrite",
 	"/react/react.usecontractevents": "/references/react/v4/useContractEvents",
 	"/react/react.usesdk": "/references/react/v4/useSDK",
-	"/react/react.useactiveclaimcondition":
-		"/references/react/v4/useActiveClaimCondition",
-	"/react/react.useactiveclaimconditionforwallet":
-		"/references/react/v4/useActiveClaimConditionForWallet",
+	"/react/react.useactiveclaimcondition": "/references/react/v4/useActiveClaimCondition",
+	"/react/react.useactiveclaimconditionforwallet": "/references/react/v4/useActiveClaimConditionForWallet",
 	"/react/react.useclaimconditions": "/references/react/v4/useClaimConditions",
 	"/react/react.useclaimerproofs": "/references/react/v4/useClaimerProofs",
-	"/react/react.useclaimineligibilityreasons":
-		"/references/react/v4/useClaimIneligibilityReasons",
-	"/react/react.usesetclaimconditions":
-		"/references/react/v4/useSetClaimConditions",
+	"/react/react.useclaimineligibilityreasons": "/references/react/v4/useClaimIneligibilityReasons",
+	"/react/react.usesetclaimconditions": "/references/react/v4/useSetClaimConditions",
 	"/react/react.usebatchestoreveal": "/references/react/v4/useBatchesToReveal",
-	"/react/react.usedelayedreveallazymint":
-		"/references/react/v4/useDelayedRevealLazyMint",
+	"/react/react.usedelayedreveallazymint": "/references/react/v4/useDelayedRevealLazyMint",
 	"/react/react.usereveallazymint": "/references/react/v4/useRevealLazyMint",
-	"/react/react.useacceptdirectlistingoffer":
-		"/references/react/v4/useAcceptDirectListingOffer",
+	"/react/react.useacceptdirectlistingoffer": "/references/react/v4/useAcceptDirectListingOffer",
 	"/react/react.useactivelistings": "/references/react/v4/useActiveListings",
 	"/react/react.useauctionwinner": "/references/react/v4/useAuctionWinner",
 	"/react/react.usebidbuffer": "/references/react/v4/useBidBuffer",
-	"/react/react.usebuydirectlisting":
-		"/references/react/v4/useBuyDirectListing",
+	"/react/react.usebuydirectlisting": "/references/react/v4/useBuyDirectListing",
 	"/react/react.usebuynow": "/references/react/v4/useBuyNow",
-	"/react/react.usecanceldirectlisting":
-		"/references/react/v4/useCancelDirectListing",
-	"/react/react.usecancelenglishauction":
-		"/references/react/v4/useCancelEnglishAuction",
+	"/react/react.usecanceldirectlisting": "/references/react/v4/useCancelDirectListing",
+	"/react/react.usecancelenglishauction": "/references/react/v4/useCancelEnglishAuction",
 	"/react/react.usecancellisting": "/references/react/v4/useCancelListing",
-	"/react/react.usecreateauctionlisting":
-		"/references/react/v4/useCreateAuctionListing",
-	"/react/react.usecreatedirectlisting":
-		"/references/react/v4/useCreateDirectListing",
+	"/react/react.usecreateauctionlisting": "/references/react/v4/useCreateAuctionListing",
+	"/react/react.usecreatedirectlisting": "/references/react/v4/useCreateDirectListing",
 	"/react/react.usedirectlisting": "/references/react/v4/useDirectListing",
 	"/react/react.usedirectlistings": "/references/react/v4/useDirectListings",
-	"/react/react.usedirectlistingscount":
-		"/references/react/v4/useDirectListingsCount",
+	"/react/react.usedirectlistingscount": "/references/react/v4/useDirectListingsCount",
 	"/react/react.useenglishauction": "/references/react/v4/useEnglishAuction",
 	"/react/react.useenglishauctions": "/references/react/v4/useEnglishAuctions",
-	"/react/react.useenglishauctionscount":
-		"/references/react/v4/useEnglishAuctionsCount",
-	"/react/react.useenglishauctionwinningbid":
-		"/references/react/v4/useEnglishAuctionWinningBid",
-	"/react/react.useexecuteauctionsale":
-		"/references/react/v4/useExecuteAuctionSale",
+	"/react/react.useenglishauctionscount": "/references/react/v4/useEnglishAuctionsCount",
+	"/react/react.useenglishauctionwinningbid": "/references/react/v4/useEnglishAuctionWinningBid",
+	"/react/react.useexecuteauctionsale": "/references/react/v4/useExecuteAuctionSale",
 	"/react/react.uselisting": "/references/react/v4/useListing",
 	"/react/react.uselistings": "/references/react/v4/useListings",
 	"/react/react.uselistingscount": "/references/react/v4/useListingsCount",
@@ -90,17 +75,13 @@ const reactRedirects = {
 	"/react/react.usemakeoffer": "/references/react/v4/useMakeOffer",
 	"/react/react.useminimumnextbid": "/references/react/v4/useMinimumNextBid",
 	"/react/react.useoffers": "/references/react/v4/useOffers",
-	"/react/react.usevaliddirectlistings":
-		"/references/react/v4/useValidDirectListings",
-	"/react/react.usevalidenglishauctions":
-		"/references/react/v4/useValidEnglishAuctions",
+	"/react/react.usevaliddirectlistings": "/references/react/v4/useValidDirectListings",
+	"/react/react.usevalidenglishauctions": "/references/react/v4/useValidEnglishAuctions",
 	"/react/react.usewinningbid": "/references/react/v4/useWinningBid",
-	"/react/react.usecompilermetadata":
-		"/references/react/v4/useCompilerMetadata",
+	"/react/react.usecompilermetadata": "/references/react/v4/useCompilerMetadata",
 	"/react/react.usecontracttype": "/references/react/v4/useContractType",
 	"/react/react.usemetadata": "/references/react/v4/useMetadata",
-	"/react/react.useresolvedmediatype":
-		"/references/react/v4/useResolvedMediaType",
+	"/react/react.useresolvedmediatype": "/references/react/v4/useResolvedMediaType",
 	"/react/react.useupdatemetadata": "/references/react/v4/useUpdateMetadata",
 	"/react/react.usechain": "/references/react/v4/useChain",
 	"/react/react.useSwitchChain": "/references/react/v4/useSwitchChain",
@@ -113,52 +94,41 @@ const reactRedirects = {
 	"/react/react.usenftbalance": "/references/react/v4/useNFTBalance",
 	"/react/react.usenfts": "/references/react/v4/useNFTs",
 	"/react/react.useownednfts": "/references/react/v4/useOwnedNFTs",
-	"/react/react.usetotalcirculatingsupply":
-		"/references/react/v4/useTotalCirculatingSupply",
+	"/react/react.usetotalcirculatingsupply": "/references/react/v4/useTotalCirculatingSupply",
 	"/react/react.usetotalcount": "/references/react/v4/useTotalCount",
 	"/react/react.usetransfernft": "/references/react/v4/useTransferNFT",
 	"/react/react.useclaimednfts": "/references/react/v4/useClaimedNFTs",
-	"/react/react.useclaimednftsupply":
-		"/references/react/v4/useClaimedNFTSupply",
+	"/react/react.useclaimednftsupply": "/references/react/v4/useClaimedNFTSupply",
 	"/react/react.useclaimnft": "/references/react/v4/useClaimNFT",
 	"/react/react.uselazymint": "/references/react/v4/useLazyMint",
-	"/react/react.useresetclaimconditions":
-		"/references/react/v4/useResetClaimConditions",
+	"/react/react.useresetclaimconditions": "/references/react/v4/useResetClaimConditions",
 	"/react/react.useunclaimednfts": "/references/react/v4/useUnclaimedNFTs",
-	"/react/react.useunclaimednftsupply":
-		"/references/react/v4/useUnclaimedNFTSupply",
+	"/react/react.useunclaimednftsupply": "/references/react/v4/useUnclaimedNFTSupply",
 	"/react/react.useallrolemembers": "/references/react/v4/useAllRoleMembers",
 	"/react/react.usegrantrole": "/references/react/v4/useGrantRole",
 	"/react/react.useisaddressrole": "/references/react/v4/useIsAddressRole",
 	"/react/react.userevokerole": "/references/react/v4/useRevokeRole",
 	"/react/react.userolemembers": "/references/react/v4/useRoleMembers",
 	"/react/react.useplatformfees": "/references/react/v4/usePlatformFees",
-	"/react/react.useprimarysalerecipient":
-		"/references/react/v4/usePrimarySaleRecipient",
+	"/react/react.useprimarysalerecipient": "/references/react/v4/usePrimarySaleRecipient",
 	"/react/react.useroyaltysettings": "/references/react/v4/useRoyaltySettings",
-	"/react/react.useupdateplatformfees":
-		"/references/react/v4/useUpdatePlatformFees",
-	"/react/react.useupdateprimarysalerecipient":
-		"/references/react/v4/useUpdatePrimarySaleRecipient",
-	"/react/react.useupdateroyaltysettings":
-		"/references/react/v4/useUpdateRoyaltySettings",
+	"/react/react.useupdateplatformfees": "/references/react/v4/useUpdatePlatformFees",
+	"/react/react.useupdateprimarysalerecipient": "/references/react/v4/useUpdatePrimarySaleRecipient",
+	"/react/react.useupdateroyaltysettings": "/references/react/v4/useUpdateRoyaltySettings",
 	"/react/react.usebalance": "/references/react/v4/useBalance",
-	"/react/react.usebalanceforaddress":
-		"/references/react/v4/useBalanceForAddress",
+	"/react/react.usebalanceforaddress": "/references/react/v4/useBalanceForAddress",
 	"/react/react.useburntoken": "/references/react/v4/useBurnToken",
 	"/react/react.useminttoken": "/references/react/v4/useMintToken",
 	"/react/react.usetokenbalance": "/references/react/v4/useTokenBalance",
 	"/react/react.usetokendecimals": "/references/react/v4/useTokenDecimals",
 	"/react/react.usetokensupply": "/references/react/v4/useTokenSupply",
-	"/react/react.usetransferbatchtoken":
-		"/references/react/v4/useTransferBatchToken",
+	"/react/react.usetransferbatchtoken": "/references/react/v4/useTransferBatchToken",
 	"/react/react.usetransfertoken": "/references/react/v4/useTransferToken",
 	"/react/react.useclaimtoken": "/references/react/v4/useClaimToken",
 	"/react/react.useconnect": "/references/react/v4/useConnect",
 	"/react/react.usedisconnect": "/references/react/v4/useDisconnect",
 	"/react/react.usewallet": "/references/react/v4/useWallet",
-	"/react/react.useconnectionstatus":
-		"/references/react/v4/useConnectionStatus",
+	"/react/react.useconnectionstatus": "/references/react/v4/useConnectionStatus",
 	"/react/react.usesigner": "/references/react/v4/useSigner",
 	"/react/react.usemetamask": "/references/react/v4/useMetamask",
 	"/react/react.usecoinbasewallet": "/references/react/v4/useCoinbaseWallet",
@@ -171,23 +141,17 @@ const reactRedirects = {
 	"/react/react.usetrustwallet": "/references/react/v4/useTrustWallet",
 	"/react/react.usebloctowallet": "/references/react/v4/useBloctoWallet",
 	"/react/react.useframewallet": "/references/react/v4/useFrameWallet",
-	"/react/react.usesetconnectedwallet":
-		"/references/react/v4/useSetConnectedWallet",
-	"/react/react.usesetconnectionstatus":
-		"/references/react/v4/useSetConnectionStatus",
-	"/react/react.usecreatewalletinstance":
-		"/references/react/v4/useCreateWalletInstance",
+	"/react/react.usesetconnectedwallet": "/references/react/v4/useSetConnectedWallet",
+	"/react/react.usesetconnectionstatus": "/references/react/v4/useSetConnectionStatus",
+	"/react/react.usecreatewalletinstance": "/references/react/v4/useCreateWalletInstance",
 	"/react/react.usewalletconfig": "/references/react/v4/useWalletConfig",
 	"/react/react.useaccountadmins": "/references/react/v4/useAccountAdmins",
-	"/react/react.useaccountadminsandsigners":
-		"/references/react/v4/useAccountAdminsAndSigners",
+	"/react/react.useaccountadminsandsigners": "/references/react/v4/useAccountAdminsAndSigners",
 	"/react/react.useaccountsigners": "/references/react/v4/useAccountSigners",
 	"/react/react.useaddadmin": "/references/react/v4/useAddAdmin",
-	"/react/react.usecreatesessionkey":
-		"/references/react/v4/useCreateSessionKey",
+	"/react/react.usecreatesessionkey": "/references/react/v4/useCreateSessionKey",
 	"/react/react.useremoveadmin": "/references/react/v4/useRemoveAdmin",
-	"/react/react.userevokesessionkey":
-		"/references/react/v4/useRevokeSessionKey",
+	"/react/react.userevokesessionkey": "/references/react/v4/useRevokeSessionKey",
 	"/react/react.uselogin": "/references/react/v4/useLogin",
 	"/react/react.uselogout": "/references/react/v4/useLogout",
 	"/react/react.useuser": "/references/react/v4/useUser",
@@ -200,135 +164,73 @@ const solidityRedirects = {
 	"/solidity": "/contracts/build",
 	"/solidity/extensions": "/contracts/build/extensions",
 	"/solidity/extensions/erc721": "/contracts/build/extensions/erc-721/ERC721",
-	"/solidity/extensions/erc1155":
-		"/contracts/build/extensions/erc-1155/ERC1155",
-	"/solidity/extensions/erc20mintable":
-		"/contracts/build/extensions/erc-20/ERC20BatchMintable",
-	"/solidity/base-contracts/erc721base":
-		"/contracts/build/base-contracts/erc-721/base",
-	"/solidity/base-contracts/erc20drop":
-		"/contracts/build/base-contracts/erc-20/drop",
-	"/solidity/base-contracts/erc721delayedreveal":
-		"/contracts/build/base-contracts/erc-721/delayed-reveal",
-	"/solidity/base-contracts/erc721drop":
-		"/contracts/build/base-contracts/erc-721/drop",
-	"/solidity/base-contracts/erc721lazymint":
-		"/contracts/build/base-contracts/erc-721/lazy-mint",
-	"/solidity/base-contracts/erc721signaturemint":
-		"/contracts/build/base-contracts/erc-721/signature-mint",
-	"/solidity/extensions/erc20claimconditions":
-		"/contracts/build/extensions/erc-20/ERC20ClaimConditions",
-	"/solidity/extensions/erc721mintable":
-		"/contracts/build/extensions/erc-721/ERC721Mintable",
-	"/solidity/extensions/erc721burnable":
-		"/contracts/build/extensions/erc-721/ERC721Burnable",
-	"/solidity/extensions/erc721batchmintable":
-		"/contracts/build/extensions/erc-721/ERC721BatchMintable",
-	"/solidity/extensions/erc721supply":
-		"/contracts/build/extensions/erc-721/ERC721Supply",
+	"/solidity/extensions/erc1155": "/contracts/build/extensions/erc-1155/ERC1155",
+	"/solidity/extensions/erc20mintable": "/contracts/build/extensions/erc-20/ERC20BatchMintable",
+	"/solidity/base-contracts/erc721base": "/contracts/build/base-contracts/erc-721/base",
+	"/solidity/base-contracts/erc20drop": "/contracts/build/base-contracts/erc-20/drop",
+	"/solidity/base-contracts/erc721delayedreveal": "/contracts/build/base-contracts/erc-721/delayed-reveal",
+	"/solidity/base-contracts/erc721drop": "/contracts/build/base-contracts/erc-721/drop",
+	"/solidity/base-contracts/erc721lazymint": "/contracts/build/base-contracts/erc-721/lazy-mint",
+	"/solidity/base-contracts/erc721signaturemint": "/contracts/build/base-contracts/erc-721/signature-mint",
+	"/solidity/extensions/erc20claimconditions": "/contracts/build/extensions/erc-20/ERC20ClaimConditions",
+	"/solidity/extensions/erc721mintable": "/contracts/build/extensions/erc-721/ERC721Mintable",
+	"/solidity/extensions/erc721burnable": "/contracts/build/extensions/erc-721/ERC721Burnable",
+	"/solidity/extensions/erc721batchmintable": "/contracts/build/extensions/erc-721/ERC721BatchMintable",
+	"/solidity/extensions/erc721supply": "/contracts/build/extensions/erc-721/ERC721Supply",
 	"/solidity/extensions/royalty": "/contracts/build/extensions/general/Royalty",
-	"/solidity/extensions/erc721claimphases":
-		"/contracts/build/extensions/erc-721/ERC721ClaimPhases",
-	"/solidity/extensions/contractmetadata":
-		"/contracts/build/extensions/general/ContractMetadata",
+	"/solidity/extensions/erc721claimphases": "/contracts/build/extensions/erc-721/ERC721ClaimPhases",
+	"/solidity/extensions/contractmetadata": "/contracts/build/extensions/general/ContractMetadata",
 	"/solidity/extensions/ownable": "/contracts/build/extensions/general/Ownable",
-	"/solidity/extensions/multicall":
-		"/contracts/build/extensions/general/Multicall",
-	"/solidity/extensions/dropsinglephase":
-		"/contracts/build/extensions/general/DropSinglePhase",
-	"/solidity/extensions/erc1155batchmintable":
-		"/contracts/build/extensions/erc-1155/ERC1155BatchMintable",
-	"/solidity/extensions/erc1155burnable":
-		"/contracts/build/extensions/erc-1155/ERC1155Burnable",
-	"/solidity/extensions/erc1155enumerable":
-		"/contracts/build/extensions/erc-1155/ERC1155Enumerable",
-	"/solidity/extensions/erc1155mintable":
-		"/contracts/build/extensions/erc-1155/ERC1155Mintable",
-	"/solidity/base-contracts/erc1155lazymint":
-		"/contracts/build/base-contracts/erc-1155/lazy-mint",
-	"/solidity/extensions/lazymint":
-		"/contracts/build/extensions/general/LazyMint",
-	"/solidity/extensions/erc1155claimcustom":
-		"/contracts/build/extensions/erc-1155/ERC1155ClaimCustom",
-	"/solidity/extensions/delayedreveal":
-		"/contracts/build/extensions/general/DelayedReveal",
-	"/solidity/extensions/erc1155dropsinglephase":
-		"/contracts/build/extensions/erc-1155/ERC1155DropSinglePhase",
-	"/solidity/extensions/erc1155claimconditions":
-		"/contracts/build/extensions/erc-1155/ERC1155ClaimConditions",
-	"/solidity/extensions/primarysale":
-		"/contracts/build/extensions/general/PrimarySale",
-	"/solidity/extensions/erc1155signaturemint":
-		"/contracts/build/extensions/erc-1155/ERC1155SignatureMint",
-	"/solidity/base-contracts/erc1155base":
-		"/contracts/build/base-contracts/erc-1155/base",
-	"/solidity/extensions/erc721revealable":
-		"/contracts/build/extensions/erc-721/ERC721Revealable",
-	"/solidity/extensions/erc1155revealable":
-		"/contracts/build/extensions/erc-1155/ERC1155Revealable",
-	"/solidity/extensions/erc20Permit":
-		"/contracts/build/extensions/erc-20/ERC20Permit",
-	"/solidity/extensions/erc20batchmintable":
-		"/contracts/build/extensions/erc-20/ERC20BatchMintable",
-	"/solidity/base-contracts/erc20base":
-		"/contracts/build/base-contracts/erc-20/base",
+	"/solidity/extensions/multicall": "/contracts/build/extensions/general/Multicall",
+	"/solidity/extensions/dropsinglephase": "/contracts/build/extensions/general/DropSinglePhase",
+	"/solidity/extensions/erc1155batchmintable": "/contracts/build/extensions/erc-1155/ERC1155BatchMintable",
+	"/solidity/extensions/erc1155burnable": "/contracts/build/extensions/erc-1155/ERC1155Burnable",
+	"/solidity/extensions/erc1155enumerable": "/contracts/build/extensions/erc-1155/ERC1155Enumerable",
+	"/solidity/extensions/erc1155mintable": "/contracts/build/extensions/erc-1155/ERC1155Mintable",
+	"/solidity/base-contracts/erc1155lazymint": "/contracts/build/base-contracts/erc-1155/lazy-mint",
+	"/solidity/extensions/lazymint": "/contracts/build/extensions/general/LazyMint",
+	"/solidity/extensions/erc1155claimcustom": "/contracts/build/extensions/erc-1155/ERC1155ClaimCustom",
+	"/solidity/extensions/delayedreveal": "/contracts/build/extensions/general/DelayedReveal",
+	"/solidity/extensions/erc1155dropsinglephase": "/contracts/build/extensions/erc-1155/ERC1155DropSinglePhase",
+	"/solidity/extensions/erc1155claimconditions": "/contracts/build/extensions/erc-1155/ERC1155ClaimConditions",
+	"/solidity/extensions/primarysale": "/contracts/build/extensions/general/PrimarySale",
+	"/solidity/extensions/erc1155signaturemint": "/contracts/build/extensions/erc-1155/ERC1155SignatureMint",
+	"/solidity/base-contracts/erc1155base": "/contracts/build/base-contracts/erc-1155/base",
+	"/solidity/extensions/erc721revealable": "/contracts/build/extensions/erc-721/ERC721Revealable",
+	"/solidity/extensions/erc1155revealable": "/contracts/build/extensions/erc-1155/ERC1155Revealable",
+	"/solidity/extensions/erc20Permit": "/contracts/build/extensions/erc-20/ERC20Permit",
+	"/solidity/extensions/erc20batchmintable": "/contracts/build/extensions/erc-20/ERC20BatchMintable",
+	"/solidity/base-contracts/erc20base": "/contracts/build/base-contracts/erc-20/base",
 	"/solidity/extensions/erc20": "/contracts/build/extensions/erc-20/ERC20",
-	"/solidity/base-contracts/erc20vote":
-		"/contracts/build/base-contracts/erc-20/vote",
-	"/solidity/extensions/base-account":
-		"/contracts/build/extensions/erc-4337/SmartWallet",
-	"/solidity/extensions/base-account-factory":
-		"/contracts/build/extensions/erc-4337/SmartWalletFactory",
+	"/solidity/base-contracts/erc20vote": "/contracts/build/base-contracts/erc-20/vote",
+	"/solidity/extensions/base-account": "/contracts/build/extensions/erc-4337/SmartWallet",
+	"/solidity/extensions/base-account-factory": "/contracts/build/extensions/erc-4337/SmartWalletFactory",
 	"/solidity/base-contracts": "/contracts/build/base-contracts",
-	"/solidity/base-contracts/account-factory":
-		"/contracts/build/base-contracts/erc-4337/account-factory",
-	"/solidity/base-contracts/account":
-		"/contracts/build/base-contracts/erc-4337/account",
-	"/solidity/base-contracts/managed-account-factory":
-		"/contracts/build/base-contracts/erc-4337/managed-account-factory",
-	"/solidity/base-contracts/managed-account":
-		"/contracts/build/base-contracts/erc-4337/managed-account",
-	"/solidity/extensions/erc721claimcustom":
-		"/contracts/build/extensions/erc-721/ERC721ClaimCustom",
-	"/solidity/extensions/permissions":
-		"/contracts/build/extensions/general/Permissions",
-	"/solidity/base-contracts/erc1155drop":
-		"/contracts/build/base-contracts/erc-1155/drop",
-	"/solidity/base-contracts/erc1155signaturemint":
-		"/contracts/build/base-contracts/erc-1155/signature-mint",
-	"/solidity/base-contracts/erc20signaturemint":
-		"/contracts/build/base-contracts/erc-20/signature-mint",
-	"/solidity/extensions/erc1155supply":
-		"/contracts/build/extensions/erc-1155/ERC1155Supply",
-	"/solidity/extensions/erc1155claimable":
-		"/contracts/build/extensions/erc-1155/ERC1155Claimable",
-	"/solidity/extensions/platformfee":
-		"/contracts/build/extensions/general/PlatformFee",
-	"/solidity/base-contracts/erc1155delayedreveal":
-		"/contracts/build/base-contracts/erc-1155/delayed-reveal",
+	"/solidity/base-contracts/account-factory": "/contracts/build/base-contracts/erc-4337/account-factory",
+	"/solidity/base-contracts/account": "/contracts/build/base-contracts/erc-4337/account",
+	"/solidity/base-contracts/managed-account-factory": "/contracts/build/base-contracts/erc-4337/managed-account-factory",
+	"/solidity/base-contracts/managed-account": "/contracts/build/base-contracts/erc-4337/managed-account",
+	"/solidity/extensions/erc721claimcustom": "/contracts/build/extensions/erc-721/ERC721ClaimCustom",
+	"/solidity/extensions/permissions": "/contracts/build/extensions/general/Permissions",
+	"/solidity/base-contracts/erc1155drop": "/contracts/build/base-contracts/erc-1155/drop",
+	"/solidity/base-contracts/erc1155signaturemint": "/contracts/build/base-contracts/erc-1155/signature-mint",
+	"/solidity/base-contracts/erc20signaturemint": "/contracts/build/base-contracts/erc-20/signature-mint",
+	"/solidity/extensions/erc1155supply": "/contracts/build/extensions/erc-1155/ERC1155Supply",
+	"/solidity/extensions/erc1155claimable": "/contracts/build/extensions/erc-1155/ERC1155Claimable",
+	"/solidity/extensions/platformfee": "/contracts/build/extensions/general/PlatformFee",
+	"/solidity/base-contracts/erc1155delayedreveal": "/contracts/build/base-contracts/erc-1155/delayed-reveal",
 	"/solidity/extensions/drop": "/contracts/build/extensions/general/Drop",
-	"/solidity/extensions/erc721claimable":
-		"/contracts/build/extensions/erc-721/ERC721Claimable",
-	"/solidity/base-contract/erc1155delayedreveal":
-		"/contracts/build/extensions/erc-1155/ERC1155Revealable",
-	"/solidity/extensions/erc721claimconditions":
-		"/contracts/build/extensions/erc-721/ERC721ClaimConditions",
-	"/solidity/extensions/erc721signaturemint":
-		"/contracts/build/extensions/erc-721/ERC721SignatureMint",
-	"/solidity/extensions/contract-metadata":
-		"/contracts/build/extensions/general/ContractMetadata",
-	"/solidity/extensions/erc1155claimphases":
-		"/contracts/build/extensions/erc-1155/ERC1155ClaimPhases",
-	"/solidity/base-contracts/staking/staking1155base":
-		"/contracts/build/base-contracts/erc-1155/staking",
-	"/solidity/base-contracts/staking/staking20base":
-		"/contracts/build/base-contracts/erc-20/staking",
-	"/solidity/base-contracts/staking/staking721base":
-		"/contracts/build/base-contracts/erc-721/staking",
-	"/solidity/base-contract/erc721delayedreveal":
-		"/contracts/build/base-contracts/erc-721/delayed-reveal",
-	"/solidity/base-contracts/smart-accounts":
-		"/contracts/build/base-contracts/erc-4337",
+	"/solidity/extensions/erc721claimable": "/contracts/build/extensions/erc-721/ERC721Claimable",
+	"/solidity/base-contract/erc1155delayedreveal": "/contracts/build/extensions/erc-1155/ERC1155Revealable",
+	"/solidity/extensions/erc721claimconditions": "/contracts/build/extensions/erc-721/ERC721ClaimConditions",
+	"/solidity/extensions/erc721signaturemint": "/contracts/build/extensions/erc-721/ERC721SignatureMint",
+	"/solidity/extensions/contract-metadata": "/contracts/build/extensions/general/ContractMetadata",
+	"/solidity/extensions/erc1155claimphases": "/contracts/build/extensions/erc-1155/ERC1155ClaimPhases",
+	"/solidity/base-contracts/staking/staking1155base": "/contracts/build/base-contracts/erc-1155/staking",
+	"/solidity/base-contracts/staking/staking20base": "/contracts/build/base-contracts/erc-20/staking",
+	"/solidity/base-contracts/staking/staking721base": "/contracts/build/base-contracts/erc-721/staking",
+	"/solidity/base-contract/erc721delayedreveal": "/contracts/build/base-contracts/erc-721/delayed-reveal",
+	"/solidity/base-contracts/smart-accounts": "/contracts/build/base-contracts/erc-4337",
 };
 
 const extensionsTable = "/typescript/v4/extensions#all-available-extensions";
@@ -337,22 +239,16 @@ const typescriptRedirects = {
 	"/typescript": "/typescript/v4",
 	"/typescript/getting-started": "/typescript/v4/getting-started",
 	"/typescript/sdk.thirdwebsdk": "/typescript/v4/getting-started",
-	"/typescript/sdk.thirdwebsdk.fromprivatekey":
-		"/references/typescript/v4/ThirdwebSDK#fromPrivateKey",
-	"/typescript/sdk.thirdwebsdk.fromwallet":
-		"/references/typescript/v4/ThirdwebSDK#fromWallet",
-	"/typescript/sdk.thirdwebsdk.fromsigner":
-		"/references/typescript/v4/ThirdwebSDK#fromSigner",
+	"/typescript/sdk.thirdwebsdk.fromprivatekey": "/references/typescript/v4/ThirdwebSDK#fromPrivateKey",
+	"/typescript/sdk.thirdwebsdk.fromwallet": "/references/typescript/v4/ThirdwebSDK#fromWallet",
+	"/typescript/sdk.thirdwebsdk.fromsigner": "/references/typescript/v4/ThirdwebSDK#fromSigner",
 	"/typescript/sdk.contractdeployer": "/typescript/v4/deploy",
-	"/typescript/sdk.contractverifier":
-		"/typescript/v4/utilities#contract-verification",
+	"/typescript/sdk.contractverifier": "/typescript/v4/utilities#contract-verification",
 	"/typescript/extensions": "/typescript/v4/extensions",
 	"/typescript/sdk.thirdwebsdk.smartcontract": "/typescript/v4/extensions",
 	"/typescript/sdk.smartcontract.call": "/typescript/v4/extensions",
-	"/typescript/sdk.smartcontract.prepare":
-		"/typescript/v4/extensions#preparing-transactions",
-	"/typescript/sdk.thirdwebsdk.detectextensions":
-		"/v4/extensions#detecting-avilable-extensions",
+	"/typescript/sdk.smartcontract.prepare": "/typescript/v4/extensions#preparing-transactions",
+	"/typescript/sdk.thirdwebsdk.detectextensions": "/v4/extensions#detecting-avilable-extensions",
 	// extensions
 	"/typescript/sdk.erc721": "/references/typescript/v4/Erc721",
 	"/typescript/sdk.erc1155": "/references/typescript/v4/Erc1155",
@@ -365,29 +261,22 @@ const reactNativeRedirects = {
 	"/react-native": "/typescript/v5/react-native",
 	"/react-native/getting-started": "/typescript/v5/react-native",
 	// wallets
-	"/react-native/react-native.embeddedwallet":
-		"/react-native/v0/wallets/embedded-wallet",
-	"/react-native/react-native.smartwallet":
-		"/react-native/v0/wallets/smartwallet",
-	"/react-native/react-native.walletconnect":
-		"/react-native/v0/wallets/walletconnect",
+	"/react-native/react-native.embeddedwallet": "/react-native/v0/wallets/embedded-wallet",
+	"/react-native/react-native.smartwallet": "/react-native/v0/wallets/smartwallet",
+	"/react-native/react-native.walletconnect": "/react-native/v0/wallets/walletconnect",
 	"/react-native/react-native.metamask": "/react-native/v0/wallets/metamask",
 	"/react-native/react-native.magic": "/react-native/v0/wallets/magiclink",
 	"/react-native/react-native.rainbow": "/react-native/v0/wallets/rainbow",
 	"/react-native/react-native.trust": "/react-native/v0/wallets/trust",
 	"/react-native/react-native.coinbase": "/react-native/v0/wallets/coinbase",
-	"/react-native/react-native.localwallet":
-		"/react-native/v0/wallets/local-wallet",
+	"/react-native/react-native.localwallet": "/react-native/v0/wallets/local-wallet",
 	// components
-	"/react-native/react-native.connectwallet":
-		"/react-native/v0/components/ConnectWallet",
-	"/react-native/react-native.web3button":
-		"/react-native/v0/components/Web3Button",
+	"/react-native/react-native.connectwallet": "/react-native/v0/components/ConnectWallet",
+	"/react-native/react-native.web3button": "/react-native/v0/components/Web3Button",
 	// others
 	"/react-native/available-hooks": "/references/react-native/v0/hooks",
 	"/react-native/react-native.uselogin": "/references/react-native/v0/useLogin",
-	"/react-native/react-native.uselogout":
-		"/references/react-native/v0/useLogout",
+	"/react-native/react-native.uselogout": "/references/react-native/v0/useLogout",
 	"/react-native/react-native.useuser": "/references/react-native/v0/useUser",
 	"/react-native/storage": "/references/react-native/v0/hooks#storage",
 	"/react-native/faq/deeplinks": "/react-native/v0/faq",
@@ -416,32 +305,27 @@ const unityRedirects = {
 	// erc721
 	"/unity/erc721": "/unity/contracts/erc721/erc721",
 	"/unity/erc721burnable": "/unity/contracts/erc721/erc721burnable",
-	"/unity/erc721claimconditions":
-		"/unity/contracts/erc721/erc721claimconditions",
+	"/unity/erc721claimconditions": "/unity/contracts/erc721/erc721claimconditions",
 	"/unity/erc721enumerable": "/unity/contracts/erc721/erc721enumerable",
 	"/unity/erc721lazymintable": "/unity/contracts/erc721/erc721lazymintable",
 	"/unity/erc721mintable": "/unity/contracts/erc721/erc721mintable",
-	"/unity/erc721signaturemint":
-		"/unity/contracts/erc721/erc721signaturemintable",
+	"/unity/erc721signaturemint": "/unity/contracts/erc721/erc721signaturemintable",
 	"/unity/erc721supply": "/unity/contracts/erc721/erc721supply",
 	"/unity/erc721tiereddrop": "/unity/contracts/erc721/erc721tiereddrop",
 	// erc1155
 	"/unity/erc1155": "/unity/contracts/erc1155/erc1155",
 	"/unity/erc1155burnable": "/unity/contracts/erc1155/erc1155burnable",
-	"/unity/erc1155claimconditions":
-		"/unity/contracts/erc1155/erc1155claimconditions",
+	"/unity/erc1155claimconditions": "/unity/contracts/erc1155/erc1155claimconditions",
 	"/unity/erc1155enumerable": "/unity/contracts/erc1155/erc1155enumerable",
 	"/unity/erc1155mintable": "/unity/contracts/erc1155/erc1155mintable",
 	"/unity/delayedreveal1155": "/unity/contracts/erc1155/erc1155",
-	"/unity/erc1155signaturemintable":
-		"/unity/contracts/erc1155/erc1155signaturemintable",
+	"/unity/erc1155signaturemintable": "/unity/contracts/erc1155/erc1155signaturemintable",
 	// erc20
 	"/unity/erc20": "/unity/contracts/erc20/erc20",
 	"/unity/erc20burnable": "/unity/contracts/erc20/erc20burnable",
 	"/unity/erc20claimconditions": "/unity/contracts/erc20/erc20claimconditions",
 	"/unity/erc20mintable": "/unity/contracts/erc20/erc20mintable",
-	"/unity/erc20signaturemintable":
-		"/unity/contracts/erc20/erc20signaturemintable",
+	"/unity/erc20signaturemintable": "/unity/contracts/erc20/erc20signaturemintable",
 	// other extensions
 	"/unity/marketplace": "/unity/contracts/marketplace",
 	"/unity/pack": "/unity/contracts/pack",
@@ -481,24 +365,15 @@ const walletRedirects = {
 	"/embedded-wallet/how-it-works": "/wallets/embedded-wallet/how-it-works",
 	"/embedded-wallet/getting-started": "/wallets/embedded-wallet/get-started",
 	"/embedded-wallet/connect": "/wallets/embedded-wallet/how-to/connect-users",
-	"/embedded-wallet/custom":
-		"/wallets/embedded-wallet/how-to/build-your-own-ui",
-	"/embedded-wallet/use":
-		"/wallets/embedded-wallet/how-to/interact-with-wallets",
-	"/embedded-wallet/interact":
-		"/wallets/embedded-wallet/how-to/interact-blockchain",
-	"/embedded-wallet/smart-wallet-and-embedded-wallet":
-		"/wallets/embedded-wallet/how-to/enable-gasless",
-	"/embedded-wallet/export-private-key":
-		"/wallets/embedded-wallet/how-to/export-private-key",
-	"/embedded-wallet/custom-auth":
-		"/wallets/embedded-wallet/custom-auth/configuration",
-	"/embedded-wallet/custom-auth-server":
-		"/wallets/embedded-wallet/custom-auth/custom-auth-server",
-	"/embedded-wallet/integrate-firebase":
-		"/wallets/embedded-wallet/custom-auth/firebase-auth",
-	"/embedded-wallet/custom-jwt-auth-server":
-		"/wallets/embedded-wallet/custom-auth/custom-jwt-auth-server",
+	"/embedded-wallet/custom": "/wallets/embedded-wallet/how-to/build-your-own-ui",
+	"/embedded-wallet/use": "/wallets/embedded-wallet/how-to/interact-with-wallets",
+	"/embedded-wallet/interact": "/wallets/embedded-wallet/how-to/interact-blockchain",
+	"/embedded-wallet/smart-wallet-and-embedded-wallet": "/wallets/embedded-wallet/how-to/enable-gasless",
+	"/embedded-wallet/export-private-key": "/wallets/embedded-wallet/how-to/export-private-key",
+	"/embedded-wallet/custom-auth": "/wallets/embedded-wallet/custom-auth/configuration",
+	"/embedded-wallet/custom-auth-server": "/wallets/embedded-wallet/custom-auth/custom-auth-server",
+	"/embedded-wallet/integrate-firebase": "/wallets/embedded-wallet/custom-auth/firebase-auth",
+	"/embedded-wallet/custom-jwt-auth-server": "/wallets/embedded-wallet/custom-auth/custom-jwt-auth-server",
 	"/embedded-wallet/faqs": "/wallets/embedded-wallet/faqs",
 	//smart wallet
 	"/smart-wallet": "/wallets/smart-wallet",
@@ -517,8 +392,7 @@ const walletRedirects = {
 	"/auth/how-auth-works/auth-api": "/connect/auth/how-it-works/api",
 	"/auth/getting-started": "/connect/auth/get-started",
 	"/auth/client-frameworks/react": "/connect/auth/client-frameworks/react",
-	"/auth/client-frameworks/react-native":
-		"/connect/auth/client-frameworks/react-native",
+	"/auth/client-frameworks/react-native": "/connect/auth/client-frameworks/react-native",
 	"/auth/server-frameworks/next": "/connect/auth/server-frameworks/next",
 	"/auth/server-frameworks/express": "/connect/auth/server-frameworks/express",
 	"/auth/integrations/next-auth": "/connect/auth/integrations/next-auth",
@@ -550,8 +424,7 @@ const walletRedirects = {
 	"/wallet/usage-with-unity-sdk": "/wallet-sdk/v2/usage",
 	// build a wallet
 	"/wallet/build-a-wallet": "/wallet-sdk/v2/build",
-	"/wallet/interfaces/abstract-client-wallet":
-		"/references/wallets/v2/AbstractClientWallet",
+	"/wallet/interfaces/abstract-client-wallet": "/references/wallets/v2/AbstractClientWallet",
 	"/wallet/interfaces/abstract-wallet": "/references/wallets/v2/AbstractWallet",
 	"/wallet/interfaces/connector": "/references/wallets/v2/Connector",
 	// wallets
@@ -572,8 +445,7 @@ const walletRedirects = {
 	"/wallet/frame": "/references/wallets/v2/FrameWallet",
 	"/wallet/phantom": "/references/wallets/v2/PhantomWallet",
 	"/wallet/aws-kms": "/references/wallets/v2/AwsKmsWallet",
-	"/wallet/aws-secrets-manager":
-		"/references/wallets/v2/AwsSecretsManagerWallet",
+	"/wallet/aws-secrets-manager": "/references/wallets/v2/AwsSecretsManagerWallet",
 	"/wallet/coin98-wallet": "/references/wallets/v2/Coin98Wallet",
 	"/wallet/core-wallet": "/references/wallets/v2/CoreWallet",
 	"/wallet/defi-wallet": "/references/wallets/v2/CryptoDefiWallet",
@@ -596,14 +468,13 @@ const paymentRedirects = {
 	"/checkouts/webhooks": "/payments/nft-checkout/webhooks",
 	"/checkouts/translations": "/payments/nft-checkout/translations",
 	"/checkouts/marketplaces": "/payments/nft-checkout/marketplaces",
-	"/checkouts/one-time-checkout-link":
-		"/payments/nft-checkout/one-time-checkout-link",
+	"/checkouts/one-time-checkout-link": "/payments/nft-checkout/one-time-checkout-link",
 	"/checkouts/custom-contracts": "/payments/nft-checkout/custom-contracts",
-	"/checkouts/pre-built-contracts":
-		"/payments/nft-checkout/pre-built-contracts",
+	"/checkouts/pre-built-contracts": "/payments/nft-checkout/pre-built-contracts",
 	"/checkouts/erc20-pricing": "/payments/nft-checkout/erc20-pricing",
 	"/checkouts/api-reference": "/payments/nft-checkout/api-reference",
 	"/checkouts/faq": "/payments/nft-checkout/faq",
+	"/payments/:match*": "/connect/pay/overview",
 };
 
 const contractRedirects = {
@@ -611,49 +482,29 @@ const contractRedirects = {
 	"/pre-built-contracts": "/contracts",
 	"/pre-built-contracts/how-it-works": "/contracts",
 	"/explore/faqs": "/contracts",
-	"/pre-built-contracts/account-factory":
-		"/contracts/explore/pre-built-contracts/account-factory",
-	"/pre-built-contracts/airdrop-erc1155-claimable":
-		"/explore/pre-built-contracts/airdrop-erc1155-claimable",
-	"/pre-built-contracts/airdrop-erc1155":
-		"/contracts/explore/pre-built-contracts/airdrop-erc1155",
-	"/pre-built-contracts/airdrop-erc20-claimable":
-		"/contracts/explore/pre-built-contracts/airdrop-erc20-claimable",
-	"/pre-built-contracts/airdrop-erc20":
-		"/contracts/explore/pre-built-contracts/airdrop-erc20",
-	"/pre-built-contracts/airdrop-erc721-claimable":
-		"/contracts/explore/pre-built-contracts/airdrop-erc721-claimable",
-	"/pre-built-contracts/airdrop-erc721":
-		"/contracts/explore/pre-built-contracts/airdrop-erc721",
-	"/pre-built-contracts/edition-drop":
-		"/contracts/explore/pre-built-contracts/edition-drop",
-	"/pre-built-contracts/edition":
-		"/contracts/explore/pre-built-contracts/edition",
-	"/pre-built-contracts/loyalty-card":
-		"/contracts/explore/pre-built-contracts/loyalty-card",
-	"/pre-built-contracts/managed-account-factory":
-		"/contracts/explore/pre-built-contracts/managed-account-factory",
-	"/pre-built-contracts/marketplace":
-		"/contracts/explore/pre-built-contracts/marketplace",
-	"/pre-built-contracts/multiwrap":
-		"/contracts/explore/pre-built-contracts/multiwrap",
-	"/pre-built-contracts/nft-collection":
-		"/contracts/explore/pre-built-contracts/nft-collection",
-	"/pre-built-contracts/nft-drop":
-		"/contracts/explore/pre-built-contracts/nft-drop",
-	"/pre-built-contracts/open-edition-erc721":
-		"/contracts/explore/pre-built-contracts/open-edition",
+	"/pre-built-contracts/account-factory": "/contracts/explore/pre-built-contracts/account-factory",
+	"/pre-built-contracts/airdrop-erc1155-claimable": "/explore/pre-built-contracts/airdrop-erc1155-claimable",
+	"/pre-built-contracts/airdrop-erc1155": "/contracts/explore/pre-built-contracts/airdrop-erc1155",
+	"/pre-built-contracts/airdrop-erc20-claimable": "/contracts/explore/pre-built-contracts/airdrop-erc20-claimable",
+	"/pre-built-contracts/airdrop-erc20": "/contracts/explore/pre-built-contracts/airdrop-erc20",
+	"/pre-built-contracts/airdrop-erc721-claimable": "/contracts/explore/pre-built-contracts/airdrop-erc721-claimable",
+	"/pre-built-contracts/airdrop-erc721": "/contracts/explore/pre-built-contracts/airdrop-erc721",
+	"/pre-built-contracts/edition-drop": "/contracts/explore/pre-built-contracts/edition-drop",
+	"/pre-built-contracts/edition": "/contracts/explore/pre-built-contracts/edition",
+	"/pre-built-contracts/loyalty-card": "/contracts/explore/pre-built-contracts/loyalty-card",
+	"/pre-built-contracts/managed-account-factory": "/contracts/explore/pre-built-contracts/managed-account-factory",
+	"/pre-built-contracts/marketplace": "/contracts/explore/pre-built-contracts/marketplace",
+	"/pre-built-contracts/multiwrap": "/contracts/explore/pre-built-contracts/multiwrap",
+	"/pre-built-contracts/nft-collection": "/contracts/explore/pre-built-contracts/nft-collection",
+	"/pre-built-contracts/nft-drop": "/contracts/explore/pre-built-contracts/nft-drop",
+	"/pre-built-contracts/open-edition-erc721": "/contracts/explore/pre-built-contracts/open-edition",
 	"/pre-built-contracts/pack": "/contracts/explore/pre-built-contracts/pack",
 	"/pre-built-contracts/signature-drop": "/contracts",
 	"/pre-built-contracts/split": "/contracts/explore/pre-built-contracts/split",
-	"/pre-built-contracts/stake-erc1155":
-		"/contracts/explore/pre-built-contracts/stake-erc1155",
-	"/pre-built-contracts/stake-erc20":
-		"/contracts/explore/pre-built-contracts/stake-erc20",
-	"/pre-built-contracts/stake-erc721":
-		"/contracts/explore/pre-built-contracts/stake-erc721",
-	"/pre-built-contracts/token-drop":
-		"/contracts/explore/pre-built-contracts/token-drop",
+	"/pre-built-contracts/stake-erc1155": "/contracts/explore/pre-built-contracts/stake-erc1155",
+	"/pre-built-contracts/stake-erc20": "/contracts/explore/pre-built-contracts/stake-erc20",
+	"/pre-built-contracts/stake-erc721": "/contracts/explore/pre-built-contracts/stake-erc721",
+	"/pre-built-contracts/token-drop": "/contracts/explore/pre-built-contracts/token-drop",
 	"/pre-built-contracts/token": "/contracts/explore/pre-built-contracts/token",
 	"/pre-built-contracts/vote": "/contracts/explore/pre-built-contracts/vote",
 	//deploy
@@ -684,23 +535,18 @@ const infrastructureRedirects = {
 	"/infrastructure/engine/get-started": "/engine/get-started",
 	"/infrastructure/engine/production-checklist": "/engine/production-checklist",
 	"/infrastructure/engine/self-host": "/engine/self-host",
-	"/infrastructure/engine/features/backend-wallets":
-		"/engine/features/backend-wallets",
+	"/infrastructure/engine/features/backend-wallets": "/engine/features/backend-wallets",
 	"/infrastructure/engine/features/contracts": "/engine/features/contracts",
 	"/infrastructure/engine/features/permissions": "/engine/features/permissions",
 	"/infrastructure/engine/features/webhooks": "/engine/features/webhooks",
-	"/infrastructure/engine/features/smart-wallets":
-		"/engine/features/smart-wallets",
+	"/infrastructure/engine/features/smart-wallets": "/engine/features/smart-wallets",
 	"/infrastructure/engine/features/relayers": "/engine/features/relayers",
-	"/infrastructure/engine/features/gasless-transactions":
-		"/engine/features/gasless-transactions",
+	"/infrastructure/engine/features/gasless-transactions": "/engine/features/gasless-transactions",
 	"/infrastructure/engine/guides/airdrop-nfts": "/engine/guides/airdrop-nfts",
 	"/infrastructure/engine/guides/nft-checkout": "/engine/guides/nft-checkout",
 	"/infrastructure/engine/guides/smart-wallets": "/engine/guides/smart-wallets",
-	"/infrastructure/engine/references/api-reference":
-		"/engine/references/api-reference",
-	"/infrastructure/engine/references/typescript":
-		"/engine/references/typescript",
+	"/infrastructure/engine/references/api-reference": "/engine/references/api-reference",
+	"/infrastructure/engine/references/typescript": "/engine/references/typescript",
 	"/infrastucture/engine/security": "/engine/security",
 	"/infrastructure/engine/faq": "/engine/faq",
 	"/guides/engine/relayer": "/engine/features/relayer",
@@ -710,10 +556,8 @@ const infrastructureRedirects = {
 	//storage
 	"/storage": "/infrastructure/storage/overview",
 	"/storage/how-storage-works": "/infrastructure/storage/how-storage-works",
-	"/storage/upload-to-ipfs":
-		"/infrastructure/storage/how-to-use-storage/upload-files-to-ipfs",
-	"/storage/host-web-app":
-		"/infrastructure/storage/how-to-use-storage/host-web-app",
+	"/storage/upload-to-ipfs": "/infrastructure/storage/how-to-use-storage/upload-files-to-ipfs",
+	"/storage/host-web-app": "/infrastructure/storage/how-to-use-storage/host-web-app",
 	//rpc-edge
 	"/rpc-edge": "/infrastructure/rpc-edge/overview",
 	"/rpc-edge/get-started": "/infrastructure/rpc-edge/get-started",
@@ -728,20 +572,16 @@ const otherRedirects = {
 	"/wallets/auth/:path*": "/connect/auth/:path*",
 	// guides
 	"/solana/:match*": "https://blog.thirdweb.com/discontinuing-solana-support/",
-	"/pre-built-contracts/solana/:match*":
-		"https://blog.thirdweb.com/discontinuing-solana-support/",
+	"/pre-built-contracts/solana/:match*": "https://blog.thirdweb.com/discontinuing-solana-support/",
 	"/learn/recipes/:match*": "https://blog.thirdweb.com/",
 	"/guides/tag/bundle-collection": "https://blog.thirdweb.com/tag/edition",
 	"/guides/tag/bundle-drop": "https://blog.thirdweb.com/tag/bundle-drop",
 	"/guides/bundle-drop": "https://blog.thirdweb.com/tag/edition-drop",
 	"/guides/splits": "https://blog.thirdweb.com/tag/split",
 	"/guides/bundle-collection": "https://blog.thirdweb.com/tag/edition",
-	"/guides/connect-wallet":
-		"https://blog.thirdweb.com/guides/add-connectwallet-to-your-website/",
-	"/guides/create-a-drop-with-thirdweb-dashboard":
-		"https://blog.thirdweb.com/guides/release-an-nft-drop-with-no-code",
-	"/guides/minting-with-signature":
-		"https://blog.thirdweb.com/guides/on-demand-minting",
+	"/guides/connect-wallet": "https://blog.thirdweb.com/guides/add-connectwallet-to-your-website/",
+	"/guides/create-a-drop-with-thirdweb-dashboard": "https://blog.thirdweb.com/guides/release-an-nft-drop-with-no-code",
+	"/guides/minting-with-signature": "https://blog.thirdweb.com/guides/on-demand-minting",
 	"/guides/nft-drop": "https://blog.thirdweb.com/tag/nft-drop",
 	"/guides/nft-collection": "https://blog.thirdweb.com/tag/nft-collection",
 	"/guides/edition-drop": "https://blog.thirdweb.com/tag/edition-drop",
@@ -753,27 +593,20 @@ const otherRedirects = {
 	"/guides/pack": "https://blog.thirdweb.com/tag/pack",
 	"/guides": "https://blog.thirdweb.com/guides",
 	"/tag/:match*": "https://blog.thirdweb.com/tag/:match*",
-	"/guides/on-demand-minting":
-		"https://blog.thirdweb.com/guides/mint-nft-unique-code",
-	"/guides/create-your-own-marketplace-with-thirdweb-typescript-sdk":
-		"https://blog.thirdweb.com/guides/nft-marketplace-with-typescript-next",
-	"/guides/create-a-pack-with-typescript-and-nextjs":
-		"https://blog.thirdweb.com/guides/create-an-nft-lootbox",
-	"/guides/randomized-nft-drop":
-		"https://blog.thirdweb.com/guides/shuffle-nft-drop",
+	"/guides/on-demand-minting": "https://blog.thirdweb.com/guides/mint-nft-unique-code",
+	"/guides/create-your-own-marketplace-with-thirdweb-typescript-sdk": "https://blog.thirdweb.com/guides/nft-marketplace-with-typescript-next",
+	"/guides/create-a-pack-with-typescript-and-nextjs": "https://blog.thirdweb.com/guides/create-an-nft-lootbox",
+	"/guides/randomized-nft-drop": "https://blog.thirdweb.com/guides/shuffle-nft-drop",
 	// solidity sdk
 	"/contracts/nft-drop": "/contracts/explore/pre-built-contracts/nft-drop",
-	"/contracts/nft-collection":
-		"contracts/explore/pre-built-contracts/nft-collection",
-	"/contracts/edition-drop":
-		"/contracts/explore/pre-built-contracts/edition-drop",
+	"/contracts/nft-collection": "contracts/explore/pre-built-contracts/nft-collection",
+	"/contracts/edition-drop": "/contracts/explore/pre-built-contracts/edition-drop",
 	"/contracts/edition": "/contracts/explore/pre-built-contracts/edition",
 	"/contracts/token-drop": "/contracts/explore/pre-built-contracts/token-drop",
 	"/contracts/token": "/contracts/explore/pre-built-contracts/token",
 	"/contracts/vote": "/contracts/explore/pre-built-contracts/vote",
 	"/contracts/split": "/contracts/explore/pre-built-contracts/split",
-	"/contracts/marketplace":
-		"/contracts/explore/pre-built-contracts/marketplace",
+	"/contracts/marketplace": "/contracts/explore/pre-built-contracts/marketplace",
 	"/contracts/pack": "/contracts/explore/pre-built-contracts/pack",
 	"/contracts/nfts-and-tokens": "/contracts",
 	"/contracts/drops": "/contracts",
@@ -781,8 +614,7 @@ const otherRedirects = {
 	// account abstraction rename
 	"/wallets/smart-wallet/:path*": "/connect/account-abstraction/:path*",
 	"/connect/smart-wallet/:path*": "/connect/account-abstraction/:path*",
-	"/unity/wallets/providers/smart-wallet":
-		"/unity/wallets/providers/account-abstraction",
+	"/unity/wallets/providers/smart-wallet": "/unity/wallets/providers/account-abstraction",
 	"/engine/features/smart-wallets": "/engine/features/account-abstraction",
 	// others
 	"/pre-built-contracts/:path*": "/contracts",
@@ -809,15 +641,11 @@ const otherRedirects = {
 	"/gaming": "/solutions/gaming/overview",
 	"/signature-minting": "/contracts/design-docs/signature-mint",
 	// in-app wallet
-	"/references/typescript/v5/embeddedWallet":
-		"/references/typescript/v5/inAppWallet",
+	"/references/typescript/v5/embeddedWallet": "/references/typescript/v5/inAppWallet",
 	"/connect/embedded-wallet/:path*": "/connect/in-app-wallet/:path*",
-	"/connect/embedded-wallet/how-to/get-embedded-wallet-details-on-server":
-		"/connect/in-app-wallet/how-to/get-in-app-wallet-details-on-server",
-	"/react-native/v0/wallets/embedded-wallet":
-		"/react-native/v0/wallets/in-app-wallet",
-	"/unity/wallets/providers/embedded-wallet":
-		"/unity/wallets/providers/in-app-wallet",
+	"/connect/embedded-wallet/how-to/get-embedded-wallet-details-on-server": "/connect/in-app-wallet/how-to/get-in-app-wallet-details-on-server",
+	"/react-native/v0/wallets/embedded-wallet": "/react-native/v0/wallets/in-app-wallet",
+	"/unity/wallets/providers/embedded-wallet": "/unity/wallets/providers/in-app-wallet",
 	// connect
 	"/connect/connect": "/connect/sign-in",
 };


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates redirect paths for React hooks in the `react` directory to `/references/react/v4/`. 

### Detailed summary
- Updated paths for React hooks in the `react` directory to `/references/react/v4/` for consistency.

> The following files were skipped due to too many changes: `redirects.mjs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->