### PR TITLE
Hide /infrastructure and /payments pages from search results

### DIFF
--- a/src/app/infrastructure/layout.tsx
+++ b/src/app/infrastructure/layout.tsx
@@ -5,7 +5,7 @@ import { createMetadata } from "@doc";
 export default async function Layout(props: { children: React.ReactNode }) {
 	return (
 		<DocLayout sideBar={sidebar} editPageButton={true}>
-			{props.children}
+			<div data-noindex>{props.children}</div>
 		</DocLayout>
 	);
 }

--- a/src/app/infrastructure/layout.tsx
+++ b/src/app/infrastructure/layout.tsx
@@ -4,8 +4,8 @@ import { createMetadata } from "@doc";
 
 export default async function Layout(props: { children: React.ReactNode }) {
 	return (
-		<DocLayout sideBar={sidebar} editPageButton={true}>
-			<div data-noindex>{props.children}</div>
+		<DocLayout sideBar={sidebar} editPageButton={true} noIndex>
+			{props.children}
 		</DocLayout>
 	);
 }

--- a/src/app/payments/layout.tsx
+++ b/src/app/payments/layout.tsx
@@ -5,7 +5,7 @@ import { createMetadata } from "@/components/Document";
 export default async function Layout(props: { children: React.ReactNode }) {
 	return (
 		<DocLayout sideBar={sidebar} editPageButton={true}>
-			{props.children}
+			<div data-noindex>{props.children}</div>
 		</DocLayout>
 	);
 }

--- a/src/app/payments/layout.tsx
+++ b/src/app/payments/layout.tsx
@@ -4,8 +4,8 @@ import { createMetadata } from "@/components/Document";
 
 export default async function Layout(props: { children: React.ReactNode }) {
 	return (
-		<DocLayout sideBar={sidebar} editPageButton={true}>
-			<div data-noindex>{props.children}</div>
+		<DocLayout sideBar={sidebar} editPageButton={true} noIndex>
+			{props.children}
 		</DocLayout>
 	);
 }

--- a/src/app/styleguide/layout.tsx
+++ b/src/app/styleguide/layout.tsx
@@ -3,8 +3,8 @@ import { sidebar } from "./sidebar";
 
 export default async function Layout(props: { children: React.ReactNode }) {
 	return (
-		<DocLayout sideBar={sidebar} editPageButton={true}>
-			<div data-noindex>{props.children}</div>
+		<DocLayout sideBar={sidebar} editPageButton={true} noIndex>
+			{props.children}
 		</DocLayout>
 	);
 }

--- a/src/components/Layouts/DocLayout.tsx
+++ b/src/components/Layouts/DocLayout.tsx
@@ -14,6 +14,7 @@ export type DocLayoutProps = {
 	editPageButton?: true;
 	showTableOfContents?: boolean;
 	sidebarHeader?: React.ReactNode;
+	noIndex?: boolean;
 };
 
 export function DocLayout(props: DocLayoutProps) {
@@ -37,7 +38,10 @@ export function DocLayout(props: DocLayoutProps) {
 			<div className="sticky top-sticky-top-height z-stickyMobileSidebar border-b bg-b-900 py-4 xl:hidden">
 				<DocSidebarMobile {...props.sideBar} header={props.sidebarHeader} />
 			</div>
-			<main className="relative flex w-full flex-col overflow-hidden">
+			<main
+				className="relative flex w-full flex-col overflow-hidden"
+				data-noindex={props.noIndex}
+			>
 				<div className="grow xl:mt-6">{props.children}</div>
 				<div className="mt-16 xl:mt-20">
 					<PageFooter editPageButton={props.editPageButton} />


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add a `noIndex` property to the `DocLayout` component in various layout files.

### Detailed summary
- Added `noIndex` property to `DocLayout` component in layout files.
- Updated `Layout` functions in `payments`, `infrastructure`, and `styleguide` directories to include `noIndex` property.
- Modified `DocLayout` component in `DocLayout.tsx` to handle `noIndex` property.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->