### PR TITLE
chore(docs): Updating documented example for createAuth

### DIFF
--- a/src/app/typescript/v5/auth/page.mdx
+++ b/src/app/typescript/v5/auth/page.mdx
@@ -31,22 +31,23 @@ const verifiedPayload = await result.json();
 
 How you store and maintain a user session is up to you, but our recommended approach is to store a JWT token in a cookie that is verified on the server. The server functions below include utility functions to generate and verify the JWT.
 
-In order to generate and verify the JWT you will also need to generate a 32 byte private key and pass that to the createAuth function. On unix-like systems this can be done with:
-
-```
-head -c 32 /dev/urandom | openssl enc | xxd -p -c 32
-```
+In order to generate and verify the JWT you will also need to generate a 32 byte private key. This can be an EOA private key or a random string of your choosing.
 
 ### Server Functions
 
 ```ts
+import { createThirdwebClient } from "thirdweb";
 import { createAuth } from "thirdweb/auth";
 import { privateKeyToAccount } from "thirdweb/wallets";
 
 const privateKey = process.env.THIRDWEB_PRIVATE_KEY;
+const thirdwebClient = createThirdwebClient({
+	secretKey: process.env.THIRDWEB_SECRET_KEY;
+});
 
 const auth = createAuth({
 	domain: "localhost:3000",
+	client: thirdwebClient,
 	adminAccount: privateKeyToAccount({client, privateKey})
 });
 

--- a/src/app/typescript/v5/auth/page.mdx
+++ b/src/app/typescript/v5/auth/page.mdx
@@ -31,14 +31,17 @@ const verifiedPayload = await result.json();
 
 How you store and maintain a user session is up to you, but our recommended approach is to store a JWT token in a cookie that is verified on the server. The server functions below include utility functions to generate and verify the JWT.
 
+In order to generate and verify the JWT you will also need to generate a 32 byte private key, `head -c 32 /dev/urandom | openssl enc | xxd -p -c 32`, and pass that to the createAuth function.
+
 ### Server Functions
 
 ```ts
 import { createAuth } from "thirdweb/auth";
+import { privateKeyToAccount } from "thirdweb/wallets";
 
 const auth = createAuth({
 	domain: "localhost:3000",
-	clientId: "1234567890", // get yours at https://thirdweb.com/dashboard/settings/api-keys
+	adminAccount: privateKeyToAccount({client, privateKey})
 });
 
 // 1. generate a login payload for a client on the server side

--- a/src/app/typescript/v5/auth/page.mdx
+++ b/src/app/typescript/v5/auth/page.mdx
@@ -31,13 +31,19 @@ const verifiedPayload = await result.json();
 
 How you store and maintain a user session is up to you, but our recommended approach is to store a JWT token in a cookie that is verified on the server. The server functions below include utility functions to generate and verify the JWT.
 
-In order to generate and verify the JWT you will also need to generate a 32 byte private key, `head -c 32 /dev/urandom | openssl enc | xxd -p -c 32`, and pass that to the createAuth function.
+In order to generate and verify the JWT you will also need to generate a 32 byte private key and pass that to the createAuth function. On unix-like systems this can be done with:
+
+```
+head -c 32 /dev/urandom | openssl enc | xxd -p -c 32
+```
 
 ### Server Functions
 
 ```ts
 import { createAuth } from "thirdweb/auth";
 import { privateKeyToAccount } from "thirdweb/wallets";
+
+const privateKey = process.env.THIRDWEB_PRIVATE_KEY;
 
 const auth = createAuth({
 	domain: "localhost:3000",

--- a/src/app/typescript/v5/auth/page.mdx
+++ b/src/app/typescript/v5/auth/page.mdx
@@ -31,7 +31,7 @@ const verifiedPayload = await result.json();
 
 How you store and maintain a user session is up to you, but our recommended approach is to store a JWT token in a cookie that is verified on the server. The server functions below include utility functions to generate and verify the JWT.
 
-In order to generate and verify the JWT you will also need to generate a 32 byte private key. This can be an EOA private key or a random string of your choosing.
+In order to generate and verify the JWT you will also need an EOA private key. This private key's wallet does not need to hold any funds, it is only used for signing.
 
 ### Server Functions
 


### PR DESCRIPTION
The documentation here has a clientID prop, which doesn't appear to exist in the createAuth function.

Additionally, if you don't provide an adminAccount you cannot then invoke the generateJWT function. 

This updates the documentation to include that information

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding functionality to generate and verify JWT tokens using an EOA private key. 

### Detailed summary
- Added import for `createThirdwebClient` from "thirdweb"
- Added import for `privateKeyToAccount` from "thirdweb/wallets"
- Defined `privateKey` variable from environment variables
- Created `thirdwebClient` using `createThirdwebClient`
- Updated `auth` object with `client` and `adminAccount` properties

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->