### PR TITLE
Update page.mdx

### DIFF
--- a/src/app/connect/pay/buy-with-fiat/page.mdx
+++ b/src/app/connect/pay/buy-with-fiat/page.mdx
@@ -28,7 +28,31 @@ Buy With Fiat enables credit and debit card purchases to complete any transactio
 
 ### Supported Countries
 
-Buy With Fiat is currently only available in the United States, excluding Hawaii.
+Buy With Fiat is available 130+ countries. The following countries are UNSUPPORTED:
+
+    Afghanistan
+    Africa (All Countries)
+    Belarus
+    Bolivia
+    China
+    Cuba
+    Colombia
+    Haiti
+    Honduras
+    Iran
+    Iraq
+    Latvia
+    Lebanon
+    Myanmar
+    Pakistan
+    Qatar
+    Russia
+    Ukraine
+    United Arab Emirates
+    Venezuela
+    Yemen
+
+All United States are supported, excluding Hawaii.
 
 ### Supported Currencies
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR expands the availability of Buy With Fiat to 130+ countries while listing 19 unsupported countries. The focus is on increasing accessibility globally.

### Detailed summary
- Buy With Fiat now available in 130+ countries
- 19 countries listed as unsupported
- All United States supported except Hawaii

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->