### PR TITLE
feat: add bodyHash to keypair auth docs

### DIFF
--- a/src/app/engine/features/keypair-authentication/page.mdx
+++ b/src/app/engine/features/keypair-authentication/page.mdx
@@ -107,6 +107,42 @@ await fetch(`${engineBaseUrl}/backend-wallet/get-all`, {
 });
 ```
 
+## Restrict the payload body (Advanced)
+
+To ensure this access token can only execute a specific payload, provide a SHA256 hash of the payload body as the `bodyHash` argument of the signed object.
+
+Example: This access token is restricted to transfer 0.1 MATIC on Polygon to 0xE68FFAE106cc68A0e36Ba9Fd86f27337E3a71da6.
+
+```typescript
+import { createHash } from "crypto";
+import jsonwebtoken from "jsonwebtoken";
+
+// Prepare the request payload body.
+const body = JSON.stringify({
+	to: "0xE68FFAE106cc68A0e36Ba9Fd86f27337E3a71da6",
+	currencyAddress: "0x0000000000000000000000000000000000000000",
+	amount: "0.1",
+});
+
+// Add a hash of `body` to the signed payload.
+const payload = {
+	iss: publicKey,
+	bodyHash: createHash("sha256").update(body).digest("hex"),
+};
+const accessToken = jsonwebtoken.sign(payload, privateKey, {
+	algorithm: "ES256",
+});
+
+// Call Engine with `body`.
+await fetch(`${engineBaseUrl}/backend-wallet/137/transfer`, {
+	headers: {
+		"Content-Type": "application/json",
+		authorization: `Bearer ${accessToken}`,
+	},
+	body,
+});
+```
+
 ## FAQ
 
 #### How do I enable this feature on my self-hosted Engine?

--- a/src/app/engine/features/keypair-authentication/page.mdx
+++ b/src/app/engine/features/keypair-authentication/page.mdx
@@ -138,6 +138,7 @@ await fetch(`${engineBaseUrl}/backend-wallet/137/transfer`, {
 	headers: {
 		"Content-Type": "application/json",
 		authorization: `Bearer ${accessToken}`,
+		"x-backend-wallet-address": "<engine_backend_wallet_address>",
 	},
 	body,
 });


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing security by restricting access tokens to specific payloads using SHA256 hash. 

### Detailed summary
- Added functionality to restrict access tokens to execute specific payloads based on SHA256 hash of the payload body.
- Included example code demonstrating how to implement this restriction.
- Improved security measures by ensuring access tokens can only perform designated actions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->