### PR TITLE
Fix sidebar behavior with anchor links

### DIFF
--- a/src/components/others/Sidebar.tsx
+++ b/src/components/others/Sidebar.tsx
@@ -84,7 +84,9 @@ function SidebarItem(props: { link: SidebarLink; onLinkClick?: () => void }) {
 		return <hr className="my-2 border-t" />;
 	}
 
-	const isActive = pathname === props.link.href;
+	const isActive = props.link.href
+		? pathMatchesHref(pathname, props.link.href)
+		: false;
 
 	const { link } = props;
 	if ("links" in link) {
@@ -142,7 +144,7 @@ function DocSidebarNonCollapsible(props: {
 }) {
 	const pathname = usePathname();
 	const { href, name, links, icon } = props.linkGroup;
-	const isCategoryActive = href && href === pathname;
+	const isCategoryActive = href ? pathMatchesHref(pathname, href) : false;
 
 	return (
 		<div className="my-4">
@@ -182,7 +184,7 @@ function DocSidebarCategory(props: {
 }) {
 	const pathname = usePathname();
 	const { href, name, links, expanded, icon } = props.linkGroup;
-	const isCategoryActive = href && href === pathname;
+	const isCategoryActive = href ? pathMatchesHref(pathname, href) : false;
 
 	const hasActiveHref = containsActiveHref(
 		{
@@ -295,19 +297,17 @@ export function DocSidebarMobile(props: ReferenceSideBarProps) {
 
 function containsActiveHref(
 	sidebarlink: SidebarLink,
-	activeLink: string,
+	pathname: string,
 ): boolean {
 	if ("links" in sidebarlink) {
-		return sidebarlink.links.some((link) =>
-			containsActiveHref(link, activeLink),
-		);
+		return sidebarlink.links.some((link) => containsActiveHref(link, pathname));
 	}
 
 	if ("separator" in sidebarlink) {
 		return false;
 	}
 
-	if (sidebarlink.href === activeLink) {
+	if (pathMatchesHref(pathname, sidebarlink.href)) {
 		return true;
 	}
 
@@ -319,4 +319,18 @@ function SidebarIcon(props: { icon: StaticImport | React.ReactElement }) {
 		return <Image src={props.icon} alt="" className="size-5" />;
 	}
 	return <div className="[&>*]:size-5">{props.icon}</div>;
+}
+
+function pathMatchesHref(pathname: string, href: string): boolean {
+	try {
+		if (href === pathname) {
+			return true;
+		} else if (pathname === new URL(href, window.location.href).pathname) {
+			return true;
+		}
+	} catch {
+		// ignore
+	}
+
+	return false;
 }

--- a/src/components/others/Sidebar.tsx
+++ b/src/components/others/Sidebar.tsx
@@ -85,7 +85,7 @@ function SidebarItem(props: { link: SidebarLink; onLinkClick?: () => void }) {
 	}
 
 	const isActive = props.link.href
-		? pathMatchesHref(pathname, props.link.href)
+		? pathMatches(pathname, props.link.href)
 		: false;
 
 	const { link } = props;
@@ -144,7 +144,7 @@ function DocSidebarNonCollapsible(props: {
 }) {
 	const pathname = usePathname();
 	const { href, name, links, icon } = props.linkGroup;
-	const isCategoryActive = href ? pathMatchesHref(pathname, href) : false;
+	const isCategoryActive = href ? pathMatches(pathname, href) : false;
 
 	return (
 		<div className="my-4">
@@ -184,7 +184,7 @@ function DocSidebarCategory(props: {
 }) {
 	const pathname = usePathname();
 	const { href, name, links, expanded, icon } = props.linkGroup;
-	const isCategoryActive = href ? pathMatchesHref(pathname, href) : false;
+	const isCategoryActive = href ? pathMatches(pathname, href) : false;
 
 	const hasActiveHref = containsActiveHref(
 		{
@@ -307,7 +307,7 @@ function containsActiveHref(
 		return false;
 	}
 
-	if (pathMatchesHref(pathname, sidebarlink.href)) {
+	if (pathMatches(pathname, sidebarlink.href)) {
 		return true;
 	}
 
@@ -321,12 +321,16 @@ function SidebarIcon(props: { icon: StaticImport | React.ReactElement }) {
 	return <div className="[&>*]:size-5">{props.icon}</div>;
 }
 
-function pathMatchesHref(pathname: string, href: string): boolean {
+function pathMatches(pathname: string, pathOrHref: string): boolean {
 	try {
-		if (href === pathname) {
+		if (pathOrHref === pathname) {
 			return true;
-		} else if (pathname === new URL(href, window.location.href).pathname) {
-			return true;
+		} else {
+			const u1 = new URL(pathname, window.location.href);
+			const u2 = new URL(pathOrHref, window.location.href);
+			if (u1.pathname === u2.pathname && u1.origin === u2.origin) {
+				return true;
+			}
 		}
 	} catch {
 		// ignore

--- a/src/components/others/Sidebar.tsx
+++ b/src/components/others/Sidebar.tsx
@@ -85,7 +85,7 @@ function SidebarItem(props: { link: SidebarLink; onLinkClick?: () => void }) {
 	}
 
 	const isActive = props.link.href
-		? pathMatches(pathname, props.link.href)
+		? isSamePage(pathname, props.link.href)
 		: false;
 
 	const { link } = props;
@@ -144,7 +144,7 @@ function DocSidebarNonCollapsible(props: {
 }) {
 	const pathname = usePathname();
 	const { href, name, links, icon } = props.linkGroup;
-	const isCategoryActive = href ? pathMatches(pathname, href) : false;
+	const isCategoryActive = href ? isSamePage(pathname, href) : false;
 
 	return (
 		<div className="my-4">
@@ -184,7 +184,7 @@ function DocSidebarCategory(props: {
 }) {
 	const pathname = usePathname();
 	const { href, name, links, expanded, icon } = props.linkGroup;
-	const isCategoryActive = href ? pathMatches(pathname, href) : false;
+	const isCategoryActive = href ? isSamePage(pathname, href) : false;
 
 	const hasActiveHref = containsActiveHref(
 		{
@@ -307,7 +307,7 @@ function containsActiveHref(
 		return false;
 	}
 
-	if (pathMatches(pathname, sidebarlink.href)) {
+	if (isSamePage(pathname, sidebarlink.href)) {
 		return true;
 	}
 
@@ -321,7 +321,7 @@ function SidebarIcon(props: { icon: StaticImport | React.ReactElement }) {
 	return <div className="[&>*]:size-5">{props.icon}</div>;
 }
 
-function pathMatches(pathname: string, pathOrHref: string): boolean {
+function isSamePage(pathname: string, pathOrHref: string): boolean {
 	try {
 		if (pathOrHref === pathname) {
 			return true;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the logic for determining active links in the sidebar components based on the current pathname.

### Detailed summary
- Updated `isActive` logic in `Sidebar.tsx` to use `isSamePage` function
- Refactored `isCategoryActive` in `DocSidebarNonCollapsible` and `DocSidebarCategory`
- Added `isSamePage` function to check if two paths are the same

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->