### PR TITLE
Fix: Update wallet compatibility table in React Native differences page

### DIFF
--- a/src/app/typescript/v5/react-native/differences/page.mdx
+++ b/src/app/typescript/v5/react-native/differences/page.mdx
@@ -6,7 +6,7 @@ The `thirdweb` package is designed to work with React Native, but there are some
 
 ### Available wallets
 
-Some wallets supported on the web are not available on React Native.
+All wallets are supported on both web and React Native
 
 | Component | React | React Native |
 | --- | --- | --- |
@@ -15,7 +15,7 @@ Some wallets supported on the web are not available on React Native.
 | `privateKeyAccount` | ✅ | ✅ |
 | `walletConnect` | ✅ | ✅ |
 | `coinbaseWallet` | ✅ | ✅ |
-| `injectedWallet` | ✅ | ❌ |
+| `injectedWallet` | ✅ | ✅ |
 
 ### UI components
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR ensures all wallets are now supported on both web and React Native. 

### Detailed summary
- Updated availability of wallets to be supported on both web and React Native
- `injectedWallet` is now supported on React Native

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->