### PR TITLE
Update redirects for React Native docs and improve Getting Started guide

### DIFF
--- a/redirects.mjs
+++ b/redirects.mjs
@@ -280,6 +280,7 @@ const reactNativeRedirects = {
 	"/react-native/react-native.useuser": "/references/react-native/v0/useUser",
 	"/react-native/storage": "/references/react-native/v0/hooks#storage",
 	"/react-native/faq/deeplinks": "/react-native/v0/faq",
+	"/typescript/v5/react-native/installation": "/typescript/v5/react-native/getting-started",
 };
 
 const unityRedirects = {

--- a/src/app/typescript/v5/react-native/getting-started/page.mdx
+++ b/src/app/typescript/v5/react-native/getting-started/page.mdx
@@ -1,8 +1,20 @@
 import { Callout, Steps, Step, GithubTemplateCard } from "@doc";
 
-# Installation
+# Getting Started
 
-To install the React Native SDK, you'll need to install the `@thirdweb/react-native-adapter` package from npm on top of the `thirdweb` package.
+### Automatic Installation
+
+We recommend starting a new thirdweb React Native project using our CLI, which sets up everything automatically for you.
+
+In your CLI, run:
+
+```bash
+npx thirdweb create --react-native
+```
+
+### Manual Installation
+
+To manually install the React Native SDK, you'll need to install the `@thirdweb/react-native-adapter` package from npm on top of the `thirdweb` package.
 
 <Steps>
 <Step title="Install the packages">


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update redirects for TypeScript v5 React Native installation and rename the page from "Installation" to "Getting Started".

### Detailed summary
- Updated redirect paths for TypeScript v5 React Native installation
- Renamed the page from "Installation" to "Getting Started"
- Updated content to reflect automatic and manual installation processes

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->