### PR TITLE
Isaac/flip pay developer fees

### DIFF
--- a/src/app/connect/pay/buy-with-crypto/fee-sharing/page.mdx
+++ b/src/app/connect/pay/buy-with-crypto/fee-sharing/page.mdx
@@ -12,9 +12,9 @@ export const metadata = createMetadata({
 
 # Fee Sharing
 
-thirdweb collects a 1% fee per end user transaction. We share 30% of this fee with you.
+thirdweb collects a 1% fee per end user transaction. We share 70% of this fee with you.
 
-For example, if a user purchases $100 worth of Polygon through your application, thirdweb charges a total of $1.00. thirdweb collects $0.70 and sends $0.30 to you.
+For example, if a user purchases $100 worth of Polygon through your application, thirdweb charges a total of $1.00. thirdweb collects $0.30 and sends $0.70 to you.
 
 To participate in fee sharing, all you need to do is set a recipient address in your dashboard. Your recipient address can be configured in your dashboard by navigating to [Connect > Pay](https://www.thirdweb.com/dashboard/connect/pay).
 

--- a/src/app/connect/pay/buy-with-crypto/overview/page.mdx
+++ b/src/app/connect/pay/buy-with-crypto/overview/page.mdx
@@ -17,7 +17,7 @@ Buy With Crypto handles the complexity of cross-chain routing by leveraging seve
 ### Features
 
 - **Free To Integrate:** No upfront costs or subscriptions. Just integrate and unlock crypto purchases instantly for your users.
-- **Fee Sharing**: Configure a recipient address for your application and instantly earn 30% on all fees collected through your application.
+- **Fee Sharing**: Configure a recipient address for your application and instantly earn 70% on all fees collected through your application.
 - **Liquidity Aggregation:** thirdweb aggregates several liquidity providers under the hood to ensure that every purchase is possible.
 
 <DocImage src={BuyWithCryptoImage} />
@@ -30,6 +30,6 @@ Buy With Crypto handles the complexity of cross-chain routing by leveraging seve
 
 ### Pricing
 
-thirdweb collects a 1% fee per end user transaction. We share 30% of this fee with you.
+thirdweb collects a 1% fee per end user transaction. We share 70% of this fee with you.
 
-For example, if a user purchases $100 worth of Polygon through your application, thirdweb charges a total of $1.00. thirdweb collects $0.70 and sends $0.30 to you.
+For example, if a user purchases $100 worth of Polygon through your application, thirdweb charges a total of $1.00. thirdweb collects $0.30 and sends $0.70 to you.

--- a/src/app/connect/pay/buy-with-crypto/page.mdx
+++ b/src/app/connect/pay/buy-with-crypto/page.mdx
@@ -20,12 +20,12 @@ Buy With Crypto handles the complexity of cross-chain routing by leveraging seve
 ## Features
 
 - **Free To Integrate:** No upfront costs or subscriptions. Just integrate and unlock crypto purchases instantly for your users.
-- **Fee Sharing**: Configure a recipient address for your application and instantly earn 30% on all fees collected through your application.
+- **Fee Sharing**: Configure a recipient address for your application and instantly earn 70% on all fees collected through your application.
 - **Liquidity Aggregation:** thirdweb aggregates several liquidity providers under the hood to ensure that every purchase is possible.
 - **Built-in Connect Support:** Buy With Crypto is enabled by default for your users through our Connect UI component.
 
 ## Pricing
 
-thirdweb collects a 1% fee per end user transaction. We share 30% of this fee with you.
+thirdweb collects a 1% fee per end user transaction. We share 70% of this fee with you.
 
-For example, if a user purchases $100 worth of Polygon through your application, thirdweb charges a total of $1.00. thirdweb collects $0.70 and sends $0.30 to you.
+For example, if a user purchases $100 worth of Polygon through your application, thirdweb charges a total of $1.00. thirdweb collects $0.30 and sends $0.70 to you.

--- a/src/app/connect/pay/faqs/page.mdx
+++ b/src/app/connect/pay/faqs/page.mdx
@@ -21,7 +21,7 @@ thirdweb takes a 1% fee on all Buy With Crypto transactions.
 
 ### How does fee sharing work for Buy With Crypto?
 
-thirdweb shares 30% of all fees collected through Buy With Crypto with our developers. Fee sharing is not currently available for Buy With Fiat transactions.
+thirdweb shares 70% of all fees collected through Buy With Crypto with our developers. Fee sharing is not currently available for Buy With Fiat transactions.
 
 ### What does the term “network fees” refer to?
 

--- a/src/app/connect/pay/overview/page.mdx
+++ b/src/app/connect/pay/overview/page.mdx
@@ -24,45 +24,46 @@ Pay allows your users to purchase cryptocurrencies and execute transactions with
 >
 	<FeatureCard
 		title="Earn money"
-		description="Receive 30% of fees on each crypto-to-crypto transaction"
+		description="Receive 70% of fees on each crypto-to-crypto transaction"
 		iconUrl="/icons/feature-cards/earn-money.svg"
 	/>
 
     <FeatureCard
     	title="Onboard users"
     	description="Fiat on-ramps to enable purchases with traditional payment methods"
-			iconUrl="/icons/feature-cards/onboard-users.svg"
+    		iconUrl="/icons/feature-cards/onboard-users.svg"
     />
-		    <FeatureCard
+    	    <FeatureCard
     	title="Enable in-app purchases"
     	description="Purchase crypto without leaving the application"
-			iconUrl="/icons/feature-cards/in-app-purchase.svg"
+    		iconUrl="/icons/feature-cards/in-app-purchase.svg"
     />
-			<FeatureCard
-		title="Chain Coverage"
-		description="Support purchases on over 20+ widely used EVM chains"
-		iconUrl="/icons/feature-cards/chain-coverage.svg"
-	/>
-		<FeatureCard
-		title="Liquidity Aggregation"
-		description="Ensure every transaction is possible"
-		iconUrl="/icons/feature-cards/liquidity-aggregation.svg"
-	/>
+    		<FeatureCard
+    	title="Chain Coverage"
+    	description="Support purchases on over 20+ widely used EVM chains"
+    	iconUrl="/icons/feature-cards/chain-coverage.svg"
+    />
+    	<FeatureCard
+    	title="Liquidity Aggregation"
+    	description="Ensure every transaction is possible"
+    	iconUrl="/icons/feature-cards/liquidity-aggregation.svg"
+    />
 
     <FeatureCard
     	title="Global Coverage"
     	description="Support for over 130+ countries"
-			iconUrl="/icons/feature-cards/global-coverage.svg"
+    		iconUrl="/icons/feature-cards/global-coverage.svg"
     />
-	    <FeatureCard
+        <FeatureCard
     	title="Integration Options"
     	description="Use pre-built modals or customize the transaction experience"
-			iconUrl="/icons/feature-cards/integration-options.svg"
+    		iconUrl="/icons/feature-cards/integration-options.svg"
     />
 
 </div>
 
 ### Use Cases
+
 - **Onramp funds directly into any transaction,** perfect for any of the following use cases:
   - **Games** selling in-game assets onchain.
   - **DEXes** looking to help users deposit funds.


### PR DESCRIPTION
- flip developer fee sharing from 30% to 70%

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update fee sharing percentages in various pages related to Buy With Crypto, increasing developer earnings from 30% to 70%.

### Detailed summary
- Increased fee sharing from 30% to 70% for Buy With Crypto transactions.
- Updated fee sharing information in multiple pages.
- Adjusted recipient address configuration for fee sharing.
- Updated pricing details for end user transactions.
- Updated feature cards to reflect the new fee sharing percentage.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->