### PR TITLE
Fix next and vite starter github links

### DIFF
--- a/src/app/typescript/v5/react/getting-started/page.mdx
+++ b/src/app/typescript/v5/react/getting-started/page.mdx
@@ -18,13 +18,13 @@ or clone the the Next.js or Vite starter repo:
 <GithubTemplateCard
 	title="Next.js + thirdweb starter repo"
 	descrption="A starter template for using the thirdweb package in a Next.js app"
-	href="https://github.com/thirdweb-dev/next-starter"
+	href="https://github.com/thirdweb-example/next-starter"
 />
 
 <GithubTemplateCard
 	title="Vite + thirdweb starter repo"
 	descrption="A starter template for using the thirdweb package in a Vite app"
-	href="https://github.com/thirdweb-dev/vite-starter"
+	href="https://github.com/thirdweb-example/vite-starter"
 />
 </Stack>
 
@@ -84,7 +84,7 @@ You only need to define the client once. Exporting the client vartiable will all
 
 <Step title="Connect a wallet">
 
-There are two ways to connect users to your app: 
+There are two ways to connect users to your app:
 
 - The prebuilt `ConnectButton` or `ConnectEmbed` components.
 - Your own custom button.
@@ -107,7 +107,7 @@ function App() {
 
 The `ConnectButton` and `ConnectEmbed` components come with built-in support for 350+ of wallets, 2000+ chains, fiat on-ramping, crypto swapping, transaction tracking, and more.
 
-You can also build your own custom button using the [`useConnect`](/typescript/v5/react/) hook. 
+You can also build your own custom button using the [`useConnect`](/typescript/v5/react/) hook.
 
 </Step>
 

--- a/src/app/typescript/v5/react/page.mdx
+++ b/src/app/typescript/v5/react/page.mdx
@@ -43,13 +43,13 @@ or clone the the Next.js or Vite starter repo:
 <GithubTemplateCard
 	title="Next.js + thirdweb starter repo"
 	descrption="A starter template for using the thirdweb package in a Next.js app"
-	href="https://github.com/thirdweb-dev/next-starter"
+	href="https://github.com/thirdweb-example/next-starter"
 />
 
 <GithubTemplateCard
 	title="Vite + thirdweb starter repo"
 	descrption="A starter template for using the thirdweb package in a Vite app"
-	href="https://github.com/thirdweb-dev/vite-starter"
+	href="https://github.com/thirdweb-example/vite-starter"
 />
 </Stack>
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update GitHub repository links and fix a typo in the `page.mdx` files, as well as correct a link in the `getting-started/page.mdx` file.

### Detailed summary
- Updated GitHub repository links for Next.js and Vite starter templates
- Fixed a typo in the `Connect a wallet` section in `page.mdx`
- Corrected a link in the `getting-started` page in `page.mdx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->