### PR TITLE
Fix typo in IAW faqs

### DIFF
--- a/src/app/connect/in-app-wallet/faqs/page.mdx
+++ b/src/app/connect/in-app-wallet/faqs/page.mdx
@@ -57,7 +57,7 @@ Yes, we show the email by default in the details modal after you connect. To dis
 
 ### Does the In-App Wallet product use smart contract wallets?
 
-The in-app wallet can be sued as a signer to a smart contract account (account abstraction), but it can also be used as a standalone EOA.
+The in-app wallet can be used as a signer to a smart contract account (account abstraction), but it can also be used as a standalone EOA.
 
 ### What happens if thirdweb ceases to exist? Will my users be able to access their wallets?
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to correct a typo in the In-App Wallet page content.

### Detailed summary
- Corrected a typo in the sentence regarding the usage of the in-app wallet as a signer to a smart contract account.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->